### PR TITLE
fix: conn_manager -> conn attribute ref

### DIFF
--- a/risingwave/core.py
+++ b/risingwave/core.py
@@ -615,7 +615,7 @@ class RisingWave(RisingWaveConnection):
         return RisingWaveConnection(self._connect(), self.rw_version)
 
     def close(self):
-        self.conn_manager.close()
+        self.conn.close()
         if self.local_risingwave is not None:
             self.local_risingwave.kill()
 


### PR DESCRIPTION
`conn_manager` is prob a leftover attribute that doesn't exist anymore. This fixes so it doesn't break when trying to do `RisingWave(...).close()`. Workaround is to do `RisingWave(...).conn.close()`.
