### PR TITLE
fix: allow read-only users and fix insert_row buffer

### DIFF
--- a/risingwave/core.py
+++ b/risingwave/core.py
@@ -362,7 +362,7 @@ class RisingWaveConnection:
         - If `force_flush` is False, the `bulk_insert_func` is used to insert the row.
         """
         fully_qual_table_name = f"{schema_name}.{table_name}"
-        if table_name not in self._insert_ctx:
+        if fully_qual_table_name not in self._insert_ctx:
             self._insert_ctx[fully_qual_table_name] = InsertContext(
                 self, table_name, schema_name
             )
@@ -638,10 +638,6 @@ class RisingWave(RisingWaveConnection):
             # wait for the meta service is up
             self.engine = self._create_engine()
             with self.getconn() as conn:
-                conn.execute(
-                    "CREATE TABLE IF NOT EXISTS _risingwave_py_version (version INT PRIMARY KEY)"
-                )
-                conn.execute("INSERT INTO _risingwave_py_version (version) VALUES (1)")
                 version = conn.fetchone("SELECT version()")[0]
                 logging.info(f"connected to RisingWave. Version: {version}")
                 self.rw_version = extract_rw_version(version)

--- a/tests/test_insert_row.py
+++ b/tests/test_insert_row.py
@@ -1,0 +1,100 @@
+"""Tests for insert_row buffer fix (GitHub issue #8)."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestInsertRowBuffer(unittest.TestCase):
+    """Test that insert_row properly reuses InsertContext for the same table."""
+
+    def test_insert_row_reuses_context(self):
+        """Verify that multiple insert_row calls reuse the same InsertContext."""
+        from risingwave.core import RisingWaveConnection
+
+        # Create a mock connection
+        mock_conn = MagicMock()
+        mock_rw_version = "1.7.0"
+
+        rw_conn = RisingWaveConnection(mock_conn, mock_rw_version)
+
+        # Mock the InsertContext to track instantiation
+        with patch("risingwave.core.InsertContext") as MockInsertContext:
+            mock_ctx = MagicMock()
+            mock_ctx.bulk_insert_func = MagicMock()
+            MockInsertContext.return_value = mock_ctx
+
+            # Call insert_row multiple times for the same table
+            rw_conn.insert_row("test_table", "public", col1="val1")
+            rw_conn.insert_row("test_table", "public", col1="val2")
+            rw_conn.insert_row("test_table", "public", col1="val3")
+
+            # InsertContext should only be created once
+            self.assertEqual(
+                MockInsertContext.call_count,
+                1,
+                "InsertContext should be created only once for the same table",
+            )
+
+            # bulk_insert_func should be called 3 times
+            self.assertEqual(
+                mock_ctx.bulk_insert_func.call_count,
+                3,
+                "bulk_insert_func should be called for each insert_row",
+            )
+
+    def test_insert_row_different_tables_different_contexts(self):
+        """Verify that different tables get different InsertContexts."""
+        from risingwave.core import RisingWaveConnection
+
+        mock_conn = MagicMock()
+        mock_rw_version = "1.7.0"
+
+        rw_conn = RisingWaveConnection(mock_conn, mock_rw_version)
+
+        with patch("risingwave.core.InsertContext") as MockInsertContext:
+            mock_ctx = MagicMock()
+            mock_ctx.bulk_insert_func = MagicMock()
+            MockInsertContext.return_value = mock_ctx
+
+            # Call insert_row for different tables
+            rw_conn.insert_row("table_a", "public", col1="val1")
+            rw_conn.insert_row("table_b", "public", col1="val2")
+            rw_conn.insert_row("table_a", "schema2", col1="val3")
+
+            # InsertContext should be created 3 times (different fully qualified names)
+            self.assertEqual(
+                MockInsertContext.call_count,
+                3,
+                "InsertContext should be created for each unique schema.table combination",
+            )
+
+    def test_insert_row_same_table_different_schema(self):
+        """Verify that same table name in different schemas get different contexts."""
+        from risingwave.core import RisingWaveConnection
+
+        mock_conn = MagicMock()
+        mock_rw_version = "1.7.0"
+
+        rw_conn = RisingWaveConnection(mock_conn, mock_rw_version)
+
+        with patch("risingwave.core.InsertContext") as MockInsertContext:
+            mock_ctx = MagicMock()
+            mock_ctx.bulk_insert_func = MagicMock()
+            MockInsertContext.return_value = mock_ctx
+
+            # Same table name, different schemas
+            rw_conn.insert_row("users", "public", col1="val1")
+            rw_conn.insert_row("users", "public", col1="val2")
+            rw_conn.insert_row("users", "analytics", col1="val3")
+            rw_conn.insert_row("users", "analytics", col1="val4")
+
+            # Should create 2 contexts: public.users and analytics.users
+            self.assertEqual(
+                MockInsertContext.call_count,
+                2,
+                "Should create separate contexts for public.users and analytics.users",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Remove unused `_risingwave_py_version` table creation that blocked read-only users
- Fix `insert_row` buffer never flushing due to dict key mismatch
- Add unit tests for `insert_row` buffer behavior

## Issues Fixed
- Fixes #19 (Allow read only users to use library)
- Fixes #20 (Implicit INSERT statement during connection init)
- Fixes #8 (insert_row never flushes the buffer)

## Changes

### 1. Remove unused version table (fixes #19, #20)
The `_risingwave_py_version` table was created and inserted into on every connection initialization, but was never actually read or used anywhere. This caused connection failures for read-only database users since they lack INSERT/CREATE permissions.

Since the table served no purpose, it was simply removed.

### 2. Fix insert_row buffer (fixes #8)
The `insert_row` method had a bug where the dictionary key check used `table_name` but the dictionary stored entries with `fully_qual_table_name` as the key:

```python
# Before (bug):
if table_name not in self._insert_ctx:
    self._insert_ctx[fully_qual_table_name] = ...

# After (fix):
if fully_qual_table_name not in self._insert_ctx:
    self._insert_ctx[fully_qual_table_name] = ...
```

This caused a new `InsertContext` to be created on every call, so the buffer never accumulated rows to trigger automatic flushing.

### 3. Add unit tests
Added tests to verify `insert_row` properly reuses `InsertContext` for the same table.

## Test plan
- [x] Unit tests pass (`python3 -m unittest tests.test_insert_row -v`)
- [x] Manual testing with read-only database user

🤖 Generated with [Claude Code](https://claude.com/claude-code)