### PR TITLE
fix: improve insert correctness and connection lifecycle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,12 @@ jobs:
         run: |
           uv sync
 
+      - name: Run checks
+        run: |
+          uv run ruff format --check risingwave tests
+          uv run ruff check risingwave tests
+          uv run python -m unittest discover -v
+
       - name: Build package
         run: |
           uv build

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ rw.fetch("SELECT * FROM test_product", format=OutputFormat.DATAFRAME)
 ```
 
 #### Subscribe changes from a table
+
+Subscriptions require RisingWave 2.3.0 or later.
+
 ```python
 # Subscribe to changes in the test_product table in a separate thread.
 # Print out the changes to console when they occur.

--- a/docs/design-review.md
+++ b/docs/design-review.md
@@ -1,0 +1,358 @@
+# Design Review and API Evolution Proposal
+
+Status: draft
+
+Reviewed revision: `ee4d749`
+
+Date: 2026-07-23
+
+## Scope
+
+This review covers the public API, connection ownership, row and DataFrame
+insertion, subscriptions, materialized views, resource cleanup, and test/CI
+coverage.
+
+The current package is compact and easy to approach, but several implicit
+behaviors make it unsafe for production use. In particular, a call that appears
+to insert a row may only buffer it in memory, one SQLAlchemy `Connection` is
+shared by otherwise unrelated operations, and a subscription cannot be stopped
+through its public API.
+
+## Implementation Status
+
+The current working tree contains backward-compatible correctness fixes for:
+
+- parameterized row insertion and safe identifier handling;
+- NULLs, quoted strings, database defaults, and unknown-column validation;
+- empty-buffer handling and flush-on-close;
+- the fully qualified DataFrame/row buffer key;
+- serialized access to shared connections and dedicated root-subscription
+  connections;
+- escaped connection URLs and validated SSL modes;
+- synchronous callback typing, RisingWave 2.3+ subscription behavior, and
+  subscription connection cleanup;
+- bound subscription checkpoint values;
+- engine and local-process cleanup;
+- retry error chaining and retry timing;
+- unit tests, Ruff, and CI enforcement.
+
+The larger interface changes described below are intentionally deferred. These
+include explicit batch writers, controllable subscription handles, separate
+sync/async clients, explicit local-process startup, and redesigned
+materialized-view ownership.
+
+## Findings
+
+### P0: row insertion builds SQL by string interpolation
+
+`InsertContext` interpolates schema, table, column names, and values directly
+into SQL.
+
+Consequences:
+
+- quotes in strings produce invalid SQL and allow SQL injection;
+- `None`, timestamps, pandas values, arrays, JSON, bytes, and NaN are not
+  serialized according to database types;
+- missing columns raise `AttributeError` because `self.full_table_name` does
+  not exist;
+- unknown columns are silently ignored;
+- default and generated columns are overwritten with `NULL`;
+- successful SQL is logged with all inserted values.
+
+Use SQLAlchemy bound parameters or DBAPI `executemany` for values. Validate and
+quote identifiers separately; identifiers cannot be made safe through value
+parameters.
+
+### P0: partial insert buffers are silently lost
+
+`insert_row()` buffers rows until the default buffer size of five is reached.
+`RisingWaveConnection.close()` does not flush the remaining rows, and no public
+`flush()` operation exists. A successful-looking sequence of one to four
+`insert_row()` calls can therefore write nothing before normal shutdown.
+
+Single-row insertion should be synchronous by default. Buffering should only be
+enabled through an explicit batch writer whose context manager flushes on a
+successful exit.
+
+### P1: DataFrame insertion does not flush the matching row buffer
+
+`RisingWaveConnection.insert()` computes `fully_qual_table_name` but tests
+`table_name in self._insert_ctx`. The mapping is keyed by fully qualified name,
+so the intended flush normally does not happen. Buffered rows can then be
+written after newer DataFrame rows.
+
+### P1: a long-lived connection is shared across threads
+
+`RisingWaveConnection` owns one SQLAlchemy `Connection`. The README and demo
+encourage using the same `RisingWave` instance for a subscription thread and
+for writes. SQLAlchemy connections and the mutable insert buffers are not safe
+for concurrent use.
+
+The client should own an `Engine`/pool. Ordinary operations should acquire a
+short-lived connection, while each active subscription should own a dedicated
+connection.
+
+### P1: connection URLs are constructed without escaping
+
+`RisingWaveConnOptions.from_connection_info()` interpolates credentials into a
+URL. Passwords containing characters such as `@` or `/` are parsed
+incorrectly. Build URLs with `sqlalchemy.engine.URL.create()` and validate
+`sslmode`.
+
+### P1: subscription lifecycle and delivery semantics are implicit
+
+`on_change()` blocks forever, returns no handle, and provides no stop or close
+operation. `SubscriptionHandler` is annotated as async but is invoked
+synchronously. Once fetching begins, transient database errors are not retried.
+Progress is stored after the handler returns, which produces at-least-once
+delivery, but that contract is not documented.
+
+The progress key and subscription identity also need an explicit consumer name
+so two independent consumers do not accidentally share a checkpoint.
+
+### P2: cleanup and diagnostics are incomplete
+
+- closing a client does not dispose its engine;
+- materialized-view connections are closed through `atexit` rather than explicit
+  ownership;
+- a locally started RisingWave process is killed without `wait()`;
+- local process output is discarded, making startup failures difficult to
+  diagnose;
+- connection retry replaces engines without disposing previous instances;
+- `_retry()` retries broad exceptions and delays once more after its final
+  failed attempt.
+
+### P2: tests and CI do not exercise public behavior
+
+The three current tests only assert that an `InsertContext` mock is reused.
+They do not execute generated SQL or cover NULLs, quotes, buffer cleanup,
+multiple schemas, concurrency, subscription recovery, or checkpoint behavior.
+The build workflow does not run unit tests or static checks. Ruff currently
+reports two `E721` errors.
+
+## API Design Goals
+
+1. A completed method call has completed its advertised operation.
+2. Resource ownership and cleanup are explicit.
+3. One client can safely be shared, but one connection cannot be shared
+   concurrently.
+4. SQL values are always bound parameters; identifier handling is centralized.
+5. Sync and async APIs are distinct rather than inferred from a callback.
+6. Subscription delivery and acknowledgement semantics are visible in the API.
+7. Existing users have a staged migration path.
+
+## Proposed Public API
+
+The examples below describe the desired contract. Names can still change before
+implementation.
+
+### Client creation and ownership
+
+```python
+from risingwave import RisingWaveClient
+
+with RisingWaveClient.connect(
+    host="localhost",
+    port=4566,
+    user="root",
+    password="secret",
+    database="dev",
+    sslmode="disable",
+) as rw:
+    rows = rw.fetch_all("SELECT * FROM public.orders WHERE id = :id", {"id": 42})
+```
+
+The client owns the engine and is safe to share between threads. Each method
+acquires a connection for the duration of the operation. `close()` disposes the
+engine and closes all resources owned by the client.
+
+Starting a local RisingWave process should be explicit:
+
+```python
+with RisingWaveClient.local() as rw:
+    ...
+```
+
+Constructing a client without connection options should not have the surprising
+side effect of starting a process.
+
+### SQL execution and result formats
+
+```python
+rw.execute("CREATE TABLE public.orders (id BIGINT, amount DECIMAL)")
+rw.execute(
+    "INSERT INTO public.orders VALUES (:id, :amount)",
+    {"id": 42, "amount": "12.50"},
+)
+
+row = rw.fetch_one("SELECT * FROM public.orders WHERE id = :id", {"id": 42})
+rows = rw.fetch_all("SELECT * FROM public.orders")
+frame = rw.fetch_dataframe("SELECT * FROM public.orders")
+```
+
+Use separate result methods instead of a positional `format` argument. All
+methods accept `params: Mapping[str, Any] | Sequence[Mapping[str, Any]] | None`.
+The sync API accepts synchronous values and callbacks only.
+
+### Row and DataFrame insertion
+
+Single-row insertion should persist before returning:
+
+```python
+rw.insert_row("public.orders", {"id": 42, "amount": "12.50"})
+rw.insert_rows(
+    "public.orders",
+    [
+        {"id": 43, "amount": "8.00"},
+        {"id": 44, "amount": None},
+    ],
+)
+rw.insert_dataframe("public.orders", frame)
+```
+
+Buffered writes should use an explicit object:
+
+```python
+with rw.batch_writer("public.orders", batch_size=500) as writer:
+    writer.add({"id": 42, "amount": "12.50"})
+    writer.add({"id": 43, "amount": None})
+    writer.flush()  # optional; successful context exit also flushes
+```
+
+The batch writer should:
+
+- bind values rather than render SQL;
+- reject unknown columns by default;
+- omit absent columns so database defaults can apply;
+- flush on successful context exit;
+- preserve buffered data when a flush fails, allowing retry or inspection;
+- reject concurrent calls unless thread safety is explicitly implemented.
+
+### Subscriptions
+
+The primitive API should be an iterator with explicit acknowledgement:
+
+```python
+from risingwave import StartPosition
+
+with rw.subscribe(
+    "public.orders_sub",
+    source="public.orders",
+    consumer="shipping-service",
+    start=StartPosition.RESUME,
+    batch_size=100,
+) as subscription:
+    for batch in subscription:
+        process(batch.rows)
+        batch.ack()
+```
+
+This makes at-least-once delivery visible: unacknowledged batches are delivered
+again after restart. The subscription owns a dedicated connection and supports
+`close()`/`stop()`.
+
+A callback API can be a convenience wrapper:
+
+```python
+subscription = rw.on_change(
+    source="public.orders",
+    consumer="shipping-service",
+    handler=process,
+)
+subscription.run()
+```
+
+An async API should be provided by a separate `AsyncRisingWaveClient`, not by
+accepting an async callback in the synchronous client.
+
+Checkpoint storage should be replaceable through a small interface. The default
+database-backed store must identify at least the database, schema,
+subscription, and consumer.
+
+### Materialized views and database objects
+
+Replace the abbreviated `mv()` method and private methods used as public
+behavior:
+
+```python
+view = rw.materialized_views.create(
+    "analytics.order_totals",
+    query="""
+        SELECT customer_id, SUM(amount) AS total
+        FROM public.orders
+        GROUP BY customer_id
+    """,
+    if_not_exists=True,
+)
+
+view.exists()
+view.subscribe(consumer="reporting-service")
+view.drop(if_exists=True)
+```
+
+`MaterializedView` should be a lightweight resource reference using the
+client's engine. It should not own an extra connection or register an `atexit`
+handler.
+
+### Errors
+
+Expose a small exception hierarchy so callers do not need to parse strings:
+
+```text
+RisingWaveError
+├── ConfigurationError
+├── ObjectNotFoundError
+├── QueryError
+├── InsertError
+└── SubscriptionError
+```
+
+Exceptions should preserve their original cause with `raise ... from error`.
+Logging should never emit bound values or credentials by default.
+
+## Compatibility Plan
+
+### Phase 1: correctness without breaking names
+
+- parameterize existing `execute`, `fetch`, and row insertion;
+- fix the fully qualified buffer key;
+- add `flush()` and flush-on-close;
+- give subscriptions dedicated connections;
+- correct the handler annotation;
+- add unit and RisingWave integration tests.
+
+### Phase 2: introduce explicit APIs
+
+- add `RisingWaveClient`;
+- add `fetch_all`, `fetch_one`, `fetch_dataframe`, `insert_rows`, and
+  `batch_writer`;
+- return a controllable `Subscription` from subscription creation;
+- add `materialized_views.create()`;
+- keep existing methods as compatibility wrappers with deprecation warnings
+  only where semantics change.
+
+### Phase 3: remove surprising behavior in the next major version
+
+- make single-row insertion synchronous;
+- remove implicit local-process startup;
+- remove the overloaded output-format argument;
+- remove async handler annotations from the sync API;
+- remove old aliases after a documented deprecation window.
+
+## Test Strategy
+
+Unit tests should cover:
+
+- bound parameters for strings, NULLs, timestamps, decimals, bytes, JSON,
+  arrays, and pandas scalar values;
+- quoted and mixed-case identifiers;
+- defaults, generated columns, missing fields, and unknown fields;
+- batch boundaries, successful close, failed flush, and retry;
+- multi-schema table identity;
+- client use from multiple threads with separate acquired connections;
+- subscription stop, reconnect, acknowledgement, and replay;
+- URL construction with reserved characters.
+
+Integration tests should run against supported RisingWave versions and verify
+real row insertion, DataFrame insertion, materialized-view creation,
+subscription cursor behavior, and checkpoint recovery.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,12 @@ Homepage = "https://github.com/risingwavelabs/risingwave-py"
 Issues = "https://github.com/risingwavelabs/risingwave-py/issues"
 
 [dependency-groups]
-dev = ["psycopg2-binary>=2.9.9", "websocket-client>=1.8.0"]
+dev = [
+    "psycopg2-binary>=2.9.9",
+    "pytest>=8.3",
+    "ruff>=0.12",
+    "websocket-client>=1.8.0",
+]
 
 
 [[tool.uv.index]]

--- a/risingwave/__init__.py
+++ b/risingwave/__init__.py
@@ -1,3 +1,15 @@
-from .core import RisingWave, Subscription, MaterializedView, OutputFormat, RisingWaveConnOptions
+from .core import (
+    RisingWave,
+    Subscription,
+    MaterializedView,
+    OutputFormat,
+    RisingWaveConnOptions,
+)
 
-__all__ = ["RisingWave", "Subscription", "MaterializedView", "OutputFormat", "RisingWaveConnOptions"]
+__all__ = [
+    "RisingWave",
+    "Subscription",
+    "MaterializedView",
+    "OutputFormat",
+    "RisingWaveConnOptions",
+]

--- a/risingwave/core.py
+++ b/risingwave/core.py
@@ -3,64 +3,74 @@ import time
 import logging
 import atexit
 import subprocess
-import traceback
 import re
+import threading
 import semver
-from urllib.parse import urlencode, quote
 
 from enum import Enum
 from shutil import which
-from datetime import datetime
-from typing import Callable, Awaitable, Any
+from typing import Callable, Any
 
-from sqlalchemy import create_engine, text
-from sqlalchemy.engine import Connection, Engine
+from sqlalchemy import create_engine, insert, table, column, text
+from sqlalchemy.engine import Connection, Engine, URL
+from sqlalchemy.sql import Executable
 import pandas as pd
 
-SubscriptionHandler = Callable[[Any], Awaitable[None]]
+SubscriptionHandler = Callable[[Any], None]
 
 DEFAULT_CURSOR_IDLE_INTERVAL_MS = 100
 DEFAULT_RW_VERSION = "1.7.0"
+MINIMAL_SUBSCRIPTION_RW_VERSION = semver.Version.parse("2.3.0")
+SCHEMA_TABLE_COLUMNS_SQL = """
+SELECT column_name
+FROM information_schema.columns
+WHERE table_name = :table_name AND table_schema = :schema_name
+ORDER BY ordinal_position
+"""
+VALID_SSL_MODES = {
+    "disable",
+    "allow",
+    "prefer",
+    "require",
+    "verify-ca",
+    "verify-full",
+}
 
 
 def _retry(f, interval_ms: int, times: int):
-    cnt = 0
-    ee = None
-    while cnt < times:
+    if interval_ms < 0:
+        raise ValueError("interval_ms must not be negative")
+    if times <= 0:
+        raise ValueError("times must be positive")
+
+    last_error = None
+    for attempt in range(times):
         try:
             return f()
         except Exception as e:
-            ee = e
-            logging.warning(
-                f"retrying function, exception: {e}, {traceback.format_exc()}"
-            )
-            cnt += 1
-            time.sleep(interval_ms / 1000)
-    raise RuntimeError(
-        f"failed to retry function, last exception is {ee}, set logging level to DEBUG for more details"
-    )
+            last_error = e
+            if attempt + 1 < times:
+                logging.warning(
+                    "retrying function after exception (%s/%s): %s",
+                    attempt + 1,
+                    times,
+                    e,
+                )
+                logging.debug("retry failure details", exc_info=True)
+                time.sleep(interval_ms / 1000)
+    raise RuntimeError("failed to retry function") from last_error
 
 
 def extract_rw_version(sql_version_output: str) -> semver.Version:
-    # Define the regular expression pattern to extract only the version string x.x.x
     pattern = r"RisingWave-(\d+\.\d+\.\d+)"
-
-    # Compile the regular expression
-    regex = re.compile(pattern)
-
-    # Search for the pattern in the input string
-    match = regex.search(sql_version_output)
-
-    # Return the matched version if found, else return default version
-    version = semver.Version.parse(DEFAULT_RW_VERSION)
-    try:
-        version = semver.Version.parse(match.group(1))
-    except Exception as e:
-        logging.error(
-            f"failed to extract RisingWave version from {sql_version_output}, exception: {e}"
+    match = re.search(pattern, sql_version_output)
+    if match is None:
+        logging.warning(
+            "failed to extract RisingWave version; using compatibility baseline %s",
+            DEFAULT_RW_VERSION,
         )
-
-    return version
+        return semver.Version.parse(DEFAULT_RW_VERSION)
+    return semver.Version.parse(match.group(1))
 
 
 class InsertContext:
@@ -71,8 +81,13 @@ class InsertContext:
         schema_name: str,
         buf_size: int = 5,
     ):
+        if buf_size <= 0:
+            raise ValueError("buf_size must be positive")
+
         result = risingwave_conn.fetch(
-            f"SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}' and table_schema = '{schema_name}'"
+            SCHEMA_TABLE_COLUMNS_SQL,
+            OutputFormat.RAW,
+            {"table_name": table_name, "schema_name": schema_name},
         )
         if result is None or len(result) == 0:
             raise RuntimeError(
@@ -81,55 +96,71 @@ class InsertContext:
 
         self.risingwave_conn: "RisingWaveConnection" = risingwave_conn
         cols = [row[0] for row in result]
-        self.stmt: str = (
-            f"INSERT INTO {schema_name}.{table_name} ({str.join(',', cols)}) VALUES "
+        self._table = table(
+            table_name,
+            *(column(column_name) for column_name in cols),
+            schema=schema_name,
         )
-        self.row_template: str = f"({str.join(',', [f'{{{col}}}' for col in cols])})"
-        self.data_buf: list = []
-        self.valid_cols: list = cols
+        self.data_buf: list[dict[str, Any]] = []
+        self.valid_cols: tuple[str, ...] = tuple(cols)
         self.buf_size: int = buf_size
         self.schema_name = schema_name
         self.table_name = table_name
+        self.full_table_name = f"{schema_name}.{table_name}"
+        self._lock = threading.RLock()
 
         def bulk_insert(**kwargs):
-            self.data_buf.append(kwargs)
-            if len(self.data_buf) >= self.buf_size:
-                self.flush()
+            with self._lock:
+                self.data_buf.append(kwargs)
+                if len(self.data_buf) >= self.buf_size:
+                    self.flush()
 
         def insert(**kwargs):
-            self.data_buf.append(kwargs)
-            self.flush()
+            with self._lock:
+                self.data_buf.append(kwargs)
+                self.flush()
 
         self.bulk_insert_func: Callable = bulk_insert
         self.insert_func: Callable = insert
 
     def flush(self):
-        valid_data = []
-        for data in self.data_buf:
-            item = dict()
-            for k in self.valid_cols:
-                if k not in data:
-                    logging.warn(
-                        f"[risingwave] missing column {k} when inserting into table: {self.full_table_name}. Fill NULL for insertion."
+        with self._lock:
+            if not self.data_buf:
+                return
+
+            valid_columns = set(self.valid_cols)
+            grouped_rows: dict[tuple[str, ...], list[dict[str, Any]]] = {}
+            for data in self.data_buf:
+                unknown_columns = set(data) - valid_columns
+                if unknown_columns:
+                    columns = ", ".join(sorted(unknown_columns))
+                    raise ValueError(
+                        f"unknown columns for {self.full_table_name}: {columns}"
                     )
-                    item[k] = "NULL"
-                elif type(data[k]) == str or type(data[k]) == datetime:
-                    item[k] = f"'{data[k]}'"
+
+                present_columns = tuple(
+                    name for name in self.valid_cols if name in data
+                )
+                grouped_rows.setdefault(present_columns, []).append(
+                    {name: data[name] for name in present_columns}
+                )
+
+            statement = insert(self._table)
+            for present_columns, rows in grouped_rows.items():
+                if present_columns:
+                    self.risingwave_conn._execute_statement(statement, rows)
                 else:
-                    item[k] = data[k]
-            valid_data.append(item)
-        stmt = self.stmt + str.join(
-            ",", [self.row_template.format(**data) for data in valid_data]
-        )
-        self.risingwave_conn.execute(stmt)
-        self.risingwave_conn.execute("FLUSH")
-        self.data_buf = []
+                    for _ in rows:
+                        self.risingwave_conn._execute_statement(statement.values())
+
+            self.risingwave_conn.execute("FLUSH")
+            self.data_buf.clear()
 
 
 class RisingWaveConnOptions:
     def __init__(self, conn_str: str):
         if conn_str.startswith("postgresql://"):
-            conn_str = conn_str.replace("postgresql://", "risingwave://")
+            conn_str = "risingwave://" + conn_str[len("postgresql://") :]
         elif not conn_str.startswith("risingwave://"):
             raise ValueError(
                 "connection string must start with 'risingwave://' or 'postgresql://'"
@@ -176,12 +207,22 @@ class RisingWaveConnOptions:
             >>> print(conn.dsn)
             'risingwave://admin:password@localhost:4566/dev?sslmode=verify-full&tenant=tenant'
         """
-        params = {"sslmode": ssl}
-        params.update(extra_params)
-        query_params = urlencode(params, quote_via=quote)
-        return cls(
-            f"risingwave://{user}:{password}@{host}:{port}/{database}?{query_params}"
+        if ssl not in VALID_SSL_MODES:
+            valid_values = ", ".join(sorted(VALID_SSL_MODES))
+            raise ValueError(f"ssl must be one of: {valid_values}")
+
+        query = {"sslmode": ssl}
+        query.update({key: str(value) for key, value in extra_params.items()})
+        url = URL.create(
+            drivername="risingwave",
+            username=user,
+            password=password,
+            host=host,
+            port=port,
+            database=database,
+            query=query,
         )
+        return cls(url.render_as_string(hide_password=False))
 
 
 class OutputFormat(Enum):
@@ -190,10 +231,47 @@ class OutputFormat(Enum):
 
 
 class RisingWaveConnection:
-    def __init__(self, conn, rw_version):
+    def __init__(self, conn, rw_version, connection_factory=None):
         self.conn: Connection = conn
         self._insert_ctx: dict[str, InsertContext] = dict()
         self.rw_version: semver.Version = rw_version
+        self._connection_factory = connection_factory
+        self._lock = threading.RLock()
+
+    @staticmethod
+    def _normalize_execute_args(args):
+        if not args:
+            return None
+        if len(args) == 1:
+            return args[0]
+        return args
+
+    def _execute_statement(self, statement: Executable, params=None):
+        with self._lock:
+            try:
+                if params is None:
+                    cursor = self.conn.execute(statement)
+                else:
+                    cursor = self.conn.execute(statement, params)
+                cursor.close()
+                logging.debug("[risingwave] successfully executed statement")
+            except Exception as error:
+                logging.error(
+                    "[risingwave] failed to execute statement (%s)",
+                    type(error).__name__,
+                )
+                raise
+
+    def _quote_identifier(self, identifier: str) -> str:
+        if not isinstance(identifier, str) or not identifier:
+            raise ValueError("SQL identifiers must be non-empty strings")
+        return self.conn.dialect.identifier_preparer.quote(identifier)
+
+    def _qualified_name(self, schema_name: str, object_name: str) -> str:
+        return (
+            f"{self._quote_identifier(schema_name)}."
+            f"{self._quote_identifier(object_name)}"
+        )
 
     def execute(self, sql: str, *args):
         """
@@ -209,13 +287,8 @@ class RisingWaveConnection:
         Returns:
             None
         """
-        try:
-            cursor = self.conn.execute(text(sql), args)
-            cursor.close()
-            logging.info(f"[risingwave] successfully executed sql: {sql}")
-        except Exception as e:
-            logging.error(f"[risingwave] failed to exeute sql: {sql}, exception: {e}")
-            raise e
+        params = self._normalize_execute_args(args)
+        self._execute_statement(text(sql), params)
 
     def fetch(self, sql: str, format=OutputFormat.RAW, *args):
         """
@@ -235,18 +308,25 @@ class RisingWaveConnection:
             Exception: If an error occurs while executing the query.
 
         """
-        try:
-            with self.conn.execute(text(sql), args) as cursor:
-                result = cursor.fetchall()
-                if format == OutputFormat.DATAFRAME:
-                    result = pd.DataFrame(data=result, columns=cursor.keys())
-            logging.debug(f"[risingwave] successfully fetched result, query: {sql}")
-            return result
-        except Exception as e:
-            logging.error(
-                f"[risingwave] failed to fetch result, query: {sql}, exception: {e}"
-            )
-            raise e
+        params = self._normalize_execute_args(args)
+        with self._lock:
+            try:
+                if params is None:
+                    cursor = self.conn.execute(text(sql))
+                else:
+                    cursor = self.conn.execute(text(sql), params)
+                with cursor:
+                    result = cursor.fetchall()
+                    if format == OutputFormat.DATAFRAME:
+                        result = pd.DataFrame(data=result, columns=cursor.keys())
+                logging.debug("[risingwave] successfully fetched result")
+                return result
+            except Exception as error:
+                logging.error(
+                    "[risingwave] failed to fetch result (%s)",
+                    type(error).__name__,
+                )
+                raise
 
     # Execute sql statement and fetch the first returned row
     def fetchone(self, sql: str, format=OutputFormat.RAW, *args):
@@ -267,17 +347,24 @@ class RisingWaveConnection:
             Exception: If an error occurs while executing the query.
 
         """
-        try:
-            with self.conn.execute(text(sql), args) as cursor:
-                result = cursor.fetchone()
-                if format == OutputFormat.DATAFRAME and result is not None:
-                    result = pd.DataFrame(data=[result], columns=cursor.keys())
-            return result
-        except Exception as e:
-            logging.error(
-                f"[risingwave] failed to fetch the last row, query: {sql}, exception: {e}"
-            )
-            raise e
+        params = self._normalize_execute_args(args)
+        with self._lock:
+            try:
+                if params is None:
+                    cursor = self.conn.execute(text(sql))
+                else:
+                    cursor = self.conn.execute(text(sql), params)
+                with cursor:
+                    result = cursor.fetchone()
+                    if format == OutputFormat.DATAFRAME and result is not None:
+                        result = pd.DataFrame(data=[result], columns=cursor.keys())
+                return result
+            except Exception as error:
+                logging.error(
+                    "[risingwave] failed to fetch one result (%s)",
+                    type(error).__name__,
+                )
+                raise
 
     def insert(
         self,
@@ -314,17 +401,18 @@ class RisingWaveConnection:
         # TODO: add support for bulk insert for DataFrame
         # For now, we need to make sure the `insert_row` buffer is cleared before inserting DataFrame
         fully_qual_table_name = f"{schema_name}.{table_name}"
-        if table_name in self._insert_ctx:
-            self._insert_ctx[fully_qual_table_name].flush()
+        with self._lock:
+            if fully_qual_table_name in self._insert_ctx:
+                self._insert_ctx[fully_qual_table_name].flush()
 
-        data.to_sql(
-            name=table_name,
-            schema=schema_name,
-            con=self.conn,
-            if_exists="append",
-            method="multi",
-            index=False,
-        )
+            data.to_sql(
+                name=table_name,
+                schema=schema_name,
+                con=self.conn,
+                if_exists="append",
+                method="multi",
+                index=False,
+            )
 
         if force_flush:
             self.execute("FLUSH")
@@ -362,14 +450,14 @@ class RisingWaveConnection:
         - If `force_flush` is False, the `bulk_insert_func` is used to insert the row.
         """
         fully_qual_table_name = f"{schema_name}.{table_name}"
-        if fully_qual_table_name not in self._insert_ctx:
-            self._insert_ctx[fully_qual_table_name] = InsertContext(
-                self, table_name, schema_name
-            )
-        ctx = self._insert_ctx[fully_qual_table_name]
-        if force_flush:
-            return ctx.insert_func(**cols)
-        else:
+        with self._lock:
+            if fully_qual_table_name not in self._insert_ctx:
+                self._insert_ctx[fully_qual_table_name] = InsertContext(
+                    self, table_name, schema_name
+                )
+            ctx = self._insert_ctx[fully_qual_table_name]
+            if force_flush:
+                return ctx.insert_func(**cols)
             return ctx.bulk_insert_func(**cols)
 
     def check_exist(self, name: str, schema_name: str = "public"):
@@ -384,13 +472,25 @@ class RisingWaveConnection:
             bool: True if the table exists, False otherwise.
         """
 
-        result = self.fetch(
-            f"SELECT * FROM information_schema.tables WHERE table_name = '{name}' and table_schema = '{schema_name}'"
+        result = self.fetchone(
+            """
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_name = :table_name AND table_schema = :schema_name
+            LIMIT 1
+            """,
+            OutputFormat.RAW,
+            {"table_name": name, "schema_name": schema_name},
         )
-        return result is not None and len(result) > 0
+        return result is not None
 
     def close(self):
-        self.conn.close()
+        with self._lock:
+            try:
+                for insert_context in self._insert_ctx.values():
+                    insert_context.flush()
+            finally:
+                self.conn.close()
 
     def __enter__(self):
         return self
@@ -432,10 +532,10 @@ class RisingWaveConnection:
         -------
         None
         """
-        MINIMAL_SUBSCRIPTION_RW_VERSION = semver.Version.parse("2.0.0")
         if self.rw_version < MINIMAL_SUBSCRIPTION_RW_VERSION:
             raise RuntimeError(
-                "on_change is not supported in RisingWave version < 2.0.0. Please upgrade RisingWave."
+                "on_change requires RisingWave 2.3.0 or later. "
+                "Please upgrade RisingWave."
             )
 
         def check_exist():
@@ -452,15 +552,27 @@ class RisingWaveConnection:
         if sub_name == "":
             sub_name = f"{subscribe_from}_sub"
 
-        sub = Subscription(
-            conn=self,
-            handler=handler,
-            schema_name=schema_name,
-            sub_name=sub_name,
-            subscribe_from=subscribe_from,
-            retention_seconds=retention_seconds,
-            persist_progress=persist_progress,
-        )
+        subscription_conn = self
+        close_connection_on_exit = False
+        if self._connection_factory is not None:
+            subscription_conn = self._connection_factory()
+            close_connection_on_exit = True
+
+        try:
+            sub = Subscription(
+                conn=subscription_conn,
+                handler=handler,
+                schema_name=schema_name,
+                sub_name=sub_name,
+                subscribe_from=subscribe_from,
+                retention_seconds=retention_seconds,
+                persist_progress=persist_progress,
+            )
+            sub.close_connection_on_exit = close_connection_on_exit
+        except Exception:
+            if close_connection_on_exit:
+                subscription_conn.close()
+            raise
         sub._run(output_format, max_batch_size)
 
 
@@ -486,14 +598,19 @@ class MaterializedView:
         atexit.register(self.conn.close)
 
     def _create(self, ignore_exist: bool = True):
+        qualified_name = self.conn._qualified_name(self.schema_name, self.name)
         if ignore_exist:
-            sql = f"CREATE MATERIALIZED VIEW IF NOT EXISTS {self.schema_name}.{self.name} AS {self.stmt}"
+            sql = (
+                f"CREATE MATERIALIZED VIEW IF NOT EXISTS "
+                f"{qualified_name} AS {self.stmt}"
+            )
         else:
-            sql = f"CREATE MATERIALIZED VIEW {self.schema_name}.{self.name} AS {self.stmt}"
+            sql = f"CREATE MATERIALIZED VIEW {qualified_name} AS {self.stmt}"
         return self.conn.execute(sql)
 
     def _delete(self):
-        sql = f"DROP MATERIALIZED VIEW {self.schema_name}.{self.name}"
+        qualified_name = self.conn._qualified_name(self.schema_name, self.name)
+        sql = f"DROP MATERIALIZED VIEW {qualified_name}"
         return self.conn.execute(sql)
 
     def on_change(
@@ -528,14 +645,24 @@ class Subscription:
         retention_seconds: int,
         persist_progress: bool = True,
     ):
+        if not callable(handler):
+            raise TypeError("handler must be callable")
+        if not isinstance(retention_seconds, int) or retention_seconds <= 0:
+            raise ValueError("retention_seconds must be a positive integer")
+
         self.conn: RisingWaveConnection = conn
         self.sub_name: str = sub_name
         self.schema_name: str = schema_name
         self.handler: SubscriptionHandler = handler
         self.persist_progress: bool = persist_progress
+        self.close_connection_on_exit = False
+        qualified_subscription = self.conn._qualified_name(schema_name, sub_name)
+        qualified_source = self.conn._qualified_name(schema_name, subscribe_from)
         _retry(
             lambda: self.conn.execute(
-                f"CREATE SUBSCRIPTION IF NOT EXISTS {self.schema_name}.{self.sub_name} FROM {self.schema_name}.{subscribe_from} WITH (retention = '{retention_seconds}s')"
+                f"CREATE SUBSCRIPTION IF NOT EXISTS {qualified_subscription} "
+                f"FROM {qualified_source} "
+                f"WITH (retention = '{retention_seconds}s')"
             ),
             1000,
             5,
@@ -556,35 +683,52 @@ class Subscription:
         wait_interval_ms: int = DEFAULT_CURSOR_IDLE_INTERVAL_MS,
         cursor_name: str = "default",
     ):
-        cursor_name = (
-            f"risingwave_py_cursor_{cursor_name}_{self.schema_name}_{self.sub_name}"
-            # https://github.com/risingwavelabs/risingwave/pull/20221
-            if self.conn.rw_version >= "2.3.0"
-            else f"{self.schema_name}.risingwave_py_cursor_{cursor_name}_{self.sub_name}"
-        )
-        print(cursor_name)
-        fully_qual_sub_name = f"{self.schema_name}.{self.sub_name}"
+        try:
+            if not isinstance(max_batch_size, int) or max_batch_size <= 0:
+                raise ValueError("max_batch_size must be a positive integer")
+            if wait_interval_ms < 0:
+                raise ValueError("wait_interval_ms must not be negative")
 
-        if self.persist_progress:
-            progress_row = self.conn.fetchone(
-                f"SELECT progress FROM risingwave_py_sub_progress WHERE sub_name = '{fully_qual_sub_name}'"
+            quoted_cursor_name = self.conn._quote_identifier(
+                f"risingwave_py_cursor_{cursor_name}_{self.schema_name}_{self.sub_name}"
             )
-            if progress_row is not None:
-                self.conn.execute(
-                    f"DECLARE {cursor_name} subscription cursor for {fully_qual_sub_name} SINCE {progress_row[0]}"
+
+            fully_qual_sub_name = f"{self.schema_name}.{self.sub_name}"
+            qualified_subscription = self.conn._qualified_name(
+                self.schema_name, self.sub_name
+            )
+
+            if self.persist_progress:
+                progress_row = self.conn.fetchone(
+                    """
+                    SELECT progress
+                    FROM risingwave_py_sub_progress
+                    WHERE sub_name = :sub_name
+                    """,
+                    OutputFormat.RAW,
+                    {"sub_name": fully_qual_sub_name},
                 )
+                if progress_row is not None:
+                    progress = int(progress_row[0])
+                    self.conn.execute(
+                        f"DECLARE {quoted_cursor_name} SUBSCRIPTION CURSOR "
+                        f"FOR {qualified_subscription} SINCE {progress}"
+                    )
+                else:
+                    self.conn.execute(
+                        f"DECLARE {quoted_cursor_name} SUBSCRIPTION CURSOR "
+                        f"FOR {qualified_subscription}"
+                    )
             else:
                 self.conn.execute(
-                    f"DECLARE {cursor_name} subscription cursor for {fully_qual_sub_name}"
+                    f"DECLARE {quoted_cursor_name} SUBSCRIPTION CURSOR "
+                    f"FOR {qualified_subscription}"
                 )
-        else:
-            self.conn.execute(
-                f"DECLARE {cursor_name} subscription cursor for {fully_qual_sub_name}"
-            )
-        while True:
-            try:
+
+            while True:
                 data = self.conn.fetch(
-                    f"FETCH {max_batch_size} FROM {cursor_name}", format=output_format
+                    f"FETCH {max_batch_size} FROM {quoted_cursor_name}",
+                    format=output_format,
                 )
                 if data is None or len(data) == 0:
                     time.sleep(wait_interval_ms / 1000)
@@ -596,23 +740,39 @@ class Subscription:
                     else:
                         progress = data[-1][-1]
                     self.conn.execute(
-                        f"INSERT INTO risingwave_py_sub_progress (sub_name, progress) VALUES ('{fully_qual_sub_name}', {progress})"
+                        """
+                        INSERT INTO risingwave_py_sub_progress (sub_name, progress)
+                        VALUES (:sub_name, :progress)
+                        """,
+                        {
+                            "sub_name": fully_qual_sub_name,
+                            "progress": int(progress),
+                        },
                     )
-            except KeyboardInterrupt:
-                logging.info(f"subscription {fully_qual_sub_name} is interrupted")
-                break
+        except KeyboardInterrupt:
+            logging.info(
+                "subscription %s.%s is interrupted",
+                self.schema_name,
+                self.sub_name,
+            )
+        finally:
+            if self.close_connection_on_exit:
+                self.conn.close()
 
 
 class RisingWave(RisingWaveConnection):
     def __init__(self, conn_options: RisingWaveConnOptions = None):
         self.local_risingwave: subprocess.Popen = None
         self.options: RisingWaveConnOptions = conn_options
-        self.rw_version: semver.Version = DEFAULT_RW_VERSION
+        self.rw_version: semver.Version = semver.Version.parse(DEFAULT_RW_VERSION)
         self.engine = None
         self.open()
 
         RisingWaveConnection.__init__(
-            self=self, conn=self._connect(), rw_version=self.rw_version
+            self=self,
+            conn=self._connect(),
+            rw_version=self.rw_version,
+            connection_factory=self.getconn,
         )
 
     def open(self):
@@ -629,20 +789,28 @@ class RisingWave(RisingWaveConnection):
                 stderr=subprocess.DEVNULL,
                 text=True,
             )
-            atexit.register(self.local_risingwave.kill)
+            atexit.register(self._stop_local_risingwave)
             self.options = RisingWaveConnOptions.from_connection_info(
                 host="localhost", port=4566, user="root", password="", database="dev"
             )
 
         def try_connect():
             # wait for the meta service is up
+            if self.engine is not None:
+                self.engine.dispose()
             self.engine = self._create_engine()
             with self.getconn() as conn:
                 version = conn.fetchone("SELECT version()")[0]
                 logging.info(f"connected to RisingWave. Version: {version}")
                 self.rw_version = extract_rw_version(version)
 
-        return _retry(try_connect, 500, 60)
+        try:
+            return _retry(try_connect, 500, 60)
+        except Exception:
+            if self.engine is not None:
+                self.engine.dispose()
+            self._stop_local_risingwave()
+            raise
 
     def _create_engine(self) -> Engine:
         return create_engine(self.options.dsn)
@@ -654,9 +822,21 @@ class RisingWave(RisingWaveConnection):
         return RisingWaveConnection(self._connect(), self.rw_version)
 
     def close(self):
-        self.conn.close()
-        if self.local_risingwave is not None:
-            self.local_risingwave.kill()
+        try:
+            super().close()
+        finally:
+            if self.engine is not None:
+                self.engine.dispose()
+            self._stop_local_risingwave()
+
+    def _stop_local_risingwave(self):
+        if self.local_risingwave is not None and self.local_risingwave.poll() is None:
+            self.local_risingwave.terminate()
+            try:
+                self.local_risingwave.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.local_risingwave.kill()
+                self.local_risingwave.wait(timeout=5)
 
     def mv(
         self,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,304 @@
+"""Unit tests for connection, insertion, and lifecycle correctness."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from semver import Version
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
+
+from risingwave.core import (
+    InsertContext,
+    OutputFormat,
+    RisingWave,
+    RisingWaveConnection,
+    RisingWaveConnOptions,
+    Subscription,
+    _retry,
+)
+
+
+class TestInsertContext(unittest.TestCase):
+    def make_context(self, columns=("name", "note"), buf_size=5):
+        connection = MagicMock(spec=RisingWaveConnection)
+        connection.fetch.return_value = [(name,) for name in columns]
+        context = InsertContext(
+            connection,
+            table_name="books",
+            schema_name="public",
+            buf_size=buf_size,
+        )
+        return connection, context
+
+    def test_flush_uses_bound_values(self):
+        connection, context = self.make_context()
+
+        context.insert_func(name="O'Reilly", note=None)
+
+        statement, rows = connection._execute_statement.call_args.args
+        self.assertNotIn("O'Reilly", str(statement))
+        self.assertEqual(rows, [{"name": "O'Reilly", "note": None}])
+        connection.execute.assert_called_once_with("FLUSH")
+        self.assertEqual(context.data_buf, [])
+
+    def test_parameterized_insert_handles_quotes_nulls_defaults_and_identifiers(
+        self,
+    ):
+        class SQLiteConnection(RisingWaveConnection):
+            def fetch(self, sql, format=OutputFormat.RAW, *args):
+                if "information_schema.columns" in sql:
+                    return [("select",), ("note",)]
+                return super().fetch(sql, format, *args)
+
+            def execute(self, sql, *args):
+                if sql == "FLUSH":
+                    return None
+                return super().execute(sql, *args)
+
+        raw_connection = create_engine("sqlite://").connect()
+        self.addCleanup(raw_connection.close)
+        raw_connection.execute(
+            text(
+                """
+                CREATE TABLE "order-events" (
+                    "select" TEXT,
+                    note TEXT DEFAULT 'default-note'
+                )
+                """
+            )
+        )
+        connection = SQLiteConnection(raw_connection, Version.parse("2.3.0"))
+        context = InsertContext(
+            connection,
+            table_name="order-events",
+            schema_name="main",
+        )
+
+        context.insert_func(**{"select": "O'Reilly", "note": None})
+        context.insert_func(**{"select": "uses-default"})
+
+        rows = connection.fetch(
+            """
+            SELECT "select", note
+            FROM "order-events"
+            ORDER BY rowid
+            """
+        )
+        self.assertEqual(
+            rows,
+            [("O'Reilly", None), ("uses-default", "default-note")],
+        )
+
+    def test_missing_columns_are_omitted_for_database_defaults(self):
+        connection, context = self.make_context()
+
+        context.insert_func(name="uses-default")
+
+        _, rows = connection._execute_statement.call_args.args
+        self.assertEqual(rows, [{"name": "uses-default"}])
+
+    def test_unknown_columns_are_rejected_and_buffer_is_retained(self):
+        connection, context = self.make_context(columns=("name",))
+
+        with self.assertRaisesRegex(ValueError, "unknown columns.*unknown"):
+            context.insert_func(name="book", unknown=True)
+
+        connection._execute_statement.assert_not_called()
+        connection.execute.assert_not_called()
+        self.assertEqual(context.data_buf, [{"name": "book", "unknown": True}])
+
+    def test_empty_flush_does_not_execute_sql(self):
+        connection, context = self.make_context()
+
+        context.flush()
+
+        connection._execute_statement.assert_not_called()
+        connection.execute.assert_not_called()
+
+    def test_invalid_buffer_size_is_rejected(self):
+        connection = MagicMock(spec=RisingWaveConnection)
+
+        with self.assertRaisesRegex(ValueError, "buf_size"):
+            InsertContext(connection, "books", "public", buf_size=0)
+
+
+class TestRisingWaveConnection(unittest.TestCase):
+    def test_execute_and_fetch_accept_parameter_mapping(self):
+        raw_connection = create_engine("sqlite://").connect()
+        self.addCleanup(raw_connection.close)
+        connection = RisingWaveConnection(raw_connection, Version.parse("2.3.0"))
+
+        result = connection.fetch(
+            "SELECT :value", OutputFormat.RAW, {"value": "O'Reilly"}
+        )
+
+        self.assertEqual(result[0][0], "O'Reilly")
+
+    def test_close_flushes_all_insert_contexts(self):
+        raw_connection = MagicMock()
+        connection = RisingWaveConnection(raw_connection, Version.parse("2.3.0"))
+        first_context = MagicMock()
+        second_context = MagicMock()
+        connection._insert_ctx = {
+            "public.first": first_context,
+            "public.second": second_context,
+        }
+
+        connection.close()
+
+        first_context.flush.assert_called_once_with()
+        second_context.flush.assert_called_once_with()
+        raw_connection.close.assert_called_once_with()
+
+    def test_dataframe_insert_flushes_fully_qualified_context(self):
+        raw_connection = MagicMock()
+        connection = RisingWaveConnection(raw_connection, Version.parse("2.3.0"))
+        insert_context = MagicMock()
+        connection._insert_ctx["analytics.events"] = insert_context
+        dataframe = MagicMock()
+
+        connection.insert(dataframe, table_name="events", schema_name="analytics")
+
+        insert_context.flush.assert_called_once_with()
+        dataframe.to_sql.assert_called_once_with(
+            name="events",
+            schema="analytics",
+            con=raw_connection,
+            if_exists="append",
+            method="multi",
+            index=False,
+        )
+
+    @patch("risingwave.core.Subscription")
+    def test_root_subscription_uses_dedicated_connection(self, subscription_class):
+        raw_connection = MagicMock()
+        dedicated_connection = MagicMock(spec=RisingWaveConnection)
+        connection_factory = MagicMock(return_value=dedicated_connection)
+        connection = RisingWaveConnection(
+            raw_connection,
+            Version.parse("2.3.0"),
+            connection_factory=connection_factory,
+        )
+        connection.check_exist = MagicMock(return_value=True)
+        subscription = subscription_class.return_value
+
+        connection.on_change(
+            subscribe_from="events",
+            handler=lambda _: None,
+            error_if_not_exist=True,
+        )
+
+        connection_factory.assert_called_once_with()
+        self.assertIs(
+            subscription_class.call_args.kwargs["conn"],
+            dedicated_connection,
+        )
+        self.assertTrue(subscription.close_connection_on_exit)
+        subscription._run.assert_called_once_with(OutputFormat.RAW, 10)
+
+    def test_subscription_requires_risingwave_2_3(self):
+        connection = RisingWaveConnection(MagicMock(), Version.parse("2.2.9"))
+
+        with self.assertRaisesRegex(RuntimeError, "2.3.0 or later"):
+            connection.on_change(
+                subscribe_from="events",
+                handler=lambda _: None,
+                error_if_not_exist=True,
+            )
+
+
+class TestConnectionOptions(unittest.TestCase):
+    def test_reserved_characters_in_credentials_are_escaped(self):
+        options = RisingWaveConnOptions.from_connection_info(
+            host="db.example",
+            port=4566,
+            user="user@example",
+            password="p@ss/word",
+            database="dev",
+        )
+
+        parsed = make_url(options.dsn)
+        self.assertEqual(parsed.username, "user@example")
+        self.assertEqual(parsed.password, "p@ss/word")
+        self.assertEqual(parsed.host, "db.example")
+        self.assertEqual(parsed.database, "dev")
+
+    def test_invalid_ssl_mode_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "ssl must be one of"):
+            RisingWaveConnOptions.from_connection_info(
+                host="localhost",
+                port=4566,
+                user="root",
+                password="",
+                database="dev",
+                ssl="invalid",
+            )
+
+
+class TestSubscription(unittest.TestCase):
+    def make_subscription(self, version="2.3.0"):
+        connection = MagicMock(spec=RisingWaveConnection)
+        connection.rw_version = Version.parse(version)
+        connection._quote_identifier.side_effect = lambda name: f'"{name}"'
+        connection._qualified_name.side_effect = lambda schema, name: (
+            f'"{schema}"."{name}"'
+        )
+        subscription = Subscription.__new__(Subscription)
+        subscription.conn = connection
+        subscription.sub_name = "events_sub"
+        subscription.schema_name = "analytics"
+        subscription.persist_progress = False
+        subscription.close_connection_on_exit = True
+        return connection, subscription
+
+    def test_invalid_batch_size_still_closes_owned_connection(self):
+        connection, subscription = self.make_subscription()
+        subscription.handler = lambda _: None
+
+        with self.assertRaisesRegex(ValueError, "max_batch_size"):
+            subscription._run(OutputFormat.RAW, max_batch_size=0)
+
+        connection.close.assert_called_once_with()
+
+    def test_handler_failure_closes_owned_connection(self):
+        connection, subscription = self.make_subscription()
+        connection.fetch.return_value = [("event",)]
+        subscription.handler = MagicMock(side_effect=ValueError("handler failed"))
+
+        with self.assertRaisesRegex(ValueError, "handler failed"):
+            subscription._run(OutputFormat.RAW, max_batch_size=10)
+
+        connection.close.assert_called_once_with()
+
+
+class TestLifecycleAndRetry(unittest.TestCase):
+    def test_retry_does_not_sleep_after_final_failure(self):
+        error = ValueError("failed")
+        operation = MagicMock(side_effect=error)
+
+        with patch("risingwave.core.time.sleep") as sleep:
+            with patch("risingwave.core.logging.warning") as warning:
+                with self.assertRaises(RuntimeError) as raised:
+                    _retry(operation, interval_ms=10, times=3)
+
+        self.assertIs(raised.exception.__cause__, error)
+        self.assertEqual(operation.call_count, 3)
+        self.assertEqual(sleep.call_count, 2)
+        self.assertEqual(warning.call_count, 2)
+
+    def test_risingwave_close_disposes_engine(self):
+        connection = MagicMock()
+        engine = MagicMock()
+        client = RisingWave.__new__(RisingWave)
+        client.local_risingwave = None
+        client.engine = engine
+        RisingWaveConnection.__init__(client, connection, Version.parse("2.3.0"))
+
+        client.close()
+
+        connection.close.assert_called_once_with()
+        engine.dispose.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,32 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.12'",
     "python_full_version == '3.11.*'",
     "python_full_version == '3.10.*'",
     "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -17,7 +38,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/25/90/5234a78dc0ef6496a6eb97b67a42a8e96742a56f7dc808cb954a85390448/greenlet-3.1.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:0bbae94a29c9e5c7e4a2b7f0aae5c17e8e90acbfd3bf6270eeba60c39fce3563", size = 271235, upload-time = "2024-09-20T17:07:18.761Z" },
     { url = "https://files.pythonhosted.org/packages/7c/16/cd631fa0ab7d06ef06387135b7549fdcc77d8d859ed770a0d28e47b20972/greenlet-3.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fde093fb93f35ca72a556cf72c92ea3ebfda3d79fc35bb19fbe685853869a83", size = 637168, upload-time = "2024-09-20T17:36:43.774Z" },
     { url = "https://files.pythonhosted.org/packages/2f/b1/aed39043a6fec33c284a2c9abd63ce191f4f1a07319340ffc04d2ed3256f/greenlet-3.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:36b89d13c49216cadb828db8dfa6ce86bbbc476a82d3a6c397f0efae0525bdd0", size = 648826, upload-time = "2024-09-20T17:39:16.921Z" },
-    { url = "https://files.pythonhosted.org/packages/76/25/40e0112f7f3ebe54e8e8ed91b2b9f970805143efef16d043dfc15e70f44b/greenlet-3.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:94b6150a85e1b33b40b1464a3f9988dcc5251d6ed06842abff82e42632fac120", size = 644443, upload-time = "2024-09-20T17:44:21.896Z" },
     { url = "https://files.pythonhosted.org/packages/fb/2f/3850b867a9af519794784a7eeed1dd5bc68ffbcc5b28cef703711025fd0a/greenlet-3.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:93147c513fac16385d1036b7e5b102c7fbbdb163d556b791f0f11eada7ba65dc", size = 643295, upload-time = "2024-09-20T17:08:37.951Z" },
     { url = "https://files.pythonhosted.org/packages/cf/69/79e4d63b9387b48939096e25115b8af7cd8a90397a304f92436bcb21f5b2/greenlet-3.1.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da7a9bff22ce038e19bf62c4dd1ec8391062878710ded0a845bcf47cc0200617", size = 599544, upload-time = "2024-09-20T17:08:27.894Z" },
     { url = "https://files.pythonhosted.org/packages/46/1d/44dbcb0e6c323bd6f71b8c2f4233766a5faf4b8948873225d34a0b7efa71/greenlet-3.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b2795058c23988728eec1f36a4e5e4ebad22f8320c85f3587b539b9ac84128d7", size = 1125456, upload-time = "2024-09-20T17:44:11.755Z" },
@@ -26,7 +46,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/62/1c2665558618553c42922ed47a4e6d6527e2fa3516a8256c2f431c5d0441/greenlet-3.1.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e4d333e558953648ca09d64f13e6d8f0523fa705f51cae3f03b5983489958c70", size = 272479, upload-time = "2024-09-20T17:07:22.332Z" },
     { url = "https://files.pythonhosted.org/packages/76/9d/421e2d5f07285b6e4e3a676b016ca781f63cfe4a0cd8eaecf3fd6f7a71ae/greenlet-3.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09fc016b73c94e98e29af67ab7b9a879c307c6731a2c9da0db5a7d9b7edd1159", size = 640404, upload-time = "2024-09-20T17:36:45.588Z" },
     { url = "https://files.pythonhosted.org/packages/e5/de/6e05f5c59262a584e502dd3d261bbdd2c97ab5416cc9c0b91ea38932a901/greenlet-3.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d5e975ca70269d66d17dd995dafc06f1b06e8cb1ec1e9ed54c1d1e4a7c4cf26e", size = 652813, upload-time = "2024-09-20T17:39:19.052Z" },
-    { url = "https://files.pythonhosted.org/packages/49/93/d5f93c84241acdea15a8fd329362c2c71c79e1a507c3f142a5d67ea435ae/greenlet-3.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b2813dc3de8c1ee3f924e4d4227999285fd335d1bcc0d2be6dc3f1f6a318ec1", size = 648517, upload-time = "2024-09-20T17:44:24.101Z" },
     { url = "https://files.pythonhosted.org/packages/15/85/72f77fc02d00470c86a5c982b8daafdf65d38aefbbe441cebff3bf7037fc/greenlet-3.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e347b3bfcf985a05e8c0b7d462ba6f15b1ee1c909e2dcad795e49e91b152c383", size = 647831, upload-time = "2024-09-20T17:08:40.577Z" },
     { url = "https://files.pythonhosted.org/packages/f7/4b/1c9695aa24f808e156c8f4813f685d975ca73c000c2a5056c514c64980f6/greenlet-3.1.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e8f8c9cb53cdac7ba9793c276acd90168f416b9ce36799b9b885790f8ad6c0a", size = 602413, upload-time = "2024-09-20T17:08:31.728Z" },
     { url = "https://files.pythonhosted.org/packages/76/70/ad6e5b31ef330f03b12559d19fda2606a522d3849cde46b24f223d6d1619/greenlet-3.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:62ee94988d6b4722ce0028644418d93a52429e977d742ca2ccbe1c4f4a792511", size = 1129619, upload-time = "2024-09-20T17:44:14.222Z" },
@@ -35,7 +54,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ec/bad1ac26764d26aa1353216fcbfa4670050f66d445448aafa227f8b16e80/greenlet-3.1.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:4afe7ea89de619adc868e087b4d2359282058479d7cfb94970adf4b55284574d", size = 274260, upload-time = "2024-09-20T17:08:07.301Z" },
     { url = "https://files.pythonhosted.org/packages/66/d4/c8c04958870f482459ab5956c2942c4ec35cac7fe245527f1039837c17a9/greenlet-3.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79", size = 649064, upload-time = "2024-09-20T17:36:47.628Z" },
     { url = "https://files.pythonhosted.org/packages/51/41/467b12a8c7c1303d20abcca145db2be4e6cd50a951fa30af48b6ec607581/greenlet-3.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3a701fe5a9695b238503ce5bbe8218e03c3bcccf7e204e455e7462d770268aa", size = 663420, upload-time = "2024-09-20T17:39:21.258Z" },
-    { url = "https://files.pythonhosted.org/packages/27/8f/2a93cd9b1e7107d5c7b3b7816eeadcac2ebcaf6d6513df9abaf0334777f6/greenlet-3.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2846930c65b47d70b9d178e89c7e1a69c95c1f68ea5aa0a58646b7a96df12441", size = 658035, upload-time = "2024-09-20T17:44:26.501Z" },
     { url = "https://files.pythonhosted.org/packages/57/5c/7c6f50cb12be092e1dccb2599be5a942c3416dbcfb76efcf54b3f8be4d8d/greenlet-3.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36", size = 660105, upload-time = "2024-09-20T17:08:42.048Z" },
     { url = "https://files.pythonhosted.org/packages/f1/66/033e58a50fd9ec9df00a8671c74f1f3a320564c6415a4ed82a1c651654ba/greenlet-3.1.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1443279c19fca463fc33e65ef2a935a5b09bb90f978beab37729e1c3c6c25fe9", size = 613077, upload-time = "2024-09-20T17:08:33.707Z" },
     { url = "https://files.pythonhosted.org/packages/19/c5/36384a06f748044d06bdd8776e231fadf92fc896bd12cb1c9f5a1bda9578/greenlet-3.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b7cede291382a78f7bb5f04a529cb18e068dd29e0fb27376074b6d0317bf4dd0", size = 1135975, upload-time = "2024-09-20T17:44:15.989Z" },
@@ -44,7 +62,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/57/0db4940cd7bb461365ca8d6fd53e68254c9dbbcc2b452e69d0d41f10a85e/greenlet-3.1.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:05175c27cb459dcfc05d026c4232f9de8913ed006d42713cb8a5137bd49375f1", size = 272990, upload-time = "2024-09-20T17:08:26.312Z" },
     { url = "https://files.pythonhosted.org/packages/1c/ec/423d113c9f74e5e402e175b157203e9102feeb7088cee844d735b28ef963/greenlet-3.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:935e943ec47c4afab8965954bf49bfa639c05d4ccf9ef6e924188f762145c0ff", size = 649175, upload-time = "2024-09-20T17:36:48.983Z" },
     { url = "https://files.pythonhosted.org/packages/a9/46/ddbd2db9ff209186b7b7c621d1432e2f21714adc988703dbdd0e65155c77/greenlet-3.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:667a9706c970cb552ede35aee17339a18e8f2a87a51fba2ed39ceeeb1004798a", size = 663425, upload-time = "2024-09-20T17:39:22.705Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/f9/9c82d6b2b04aa37e38e74f0c429aece5eeb02bab6e3b98e7db89b23d94c6/greenlet-3.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8a678974d1f3aa55f6cc34dc480169d58f2e6d8958895d68845fa4ab566509e", size = 657736, upload-time = "2024-09-20T17:44:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/d9/42/b87bc2a81e3a62c3de2b0d550bf91a86939442b7ff85abb94eec3fc0e6aa/greenlet-3.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efc0f674aa41b92da8c49e0346318c6075d734994c3c4e4430b1c3f853e498e4", size = 660347, upload-time = "2024-09-20T17:08:45.56Z" },
     { url = "https://files.pythonhosted.org/packages/37/fa/71599c3fd06336cdc3eac52e6871cfebab4d9d70674a9a9e7a482c318e99/greenlet-3.1.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0153404a4bb921f0ff1abeb5ce8a5131da56b953eda6e14b88dc6bbc04d2049e", size = 615583, upload-time = "2024-09-20T17:08:36.85Z" },
     { url = "https://files.pythonhosted.org/packages/4e/96/e9ef85de031703ee7a4483489b40cf307f93c1824a02e903106f2ea315fe/greenlet-3.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:275f72decf9932639c1c6dd1013a1bc266438eb32710016a1c742df5da6e60a1", size = 1133039, upload-time = "2024-09-20T17:44:18.287Z" },
@@ -52,7 +69,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/1b/54336d876186920e185066d8c3024ad55f21d7cc3683c856127ddb7b13ce/greenlet-3.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:b42703b1cf69f2aa1df7d1030b9d77d3e584a70755674d60e710f0af570f3761", size = 299490, upload-time = "2024-09-20T17:17:09.501Z" },
     { url = "https://files.pythonhosted.org/packages/5f/17/bea55bf36990e1638a2af5ba10c1640273ef20f627962cf97107f1e5d637/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1695e76146579f8c06c1509c7ce4dfe0706f49c6831a817ac04eebb2fd02011", size = 643731, upload-time = "2024-09-20T17:36:50.376Z" },
     { url = "https://files.pythonhosted.org/packages/78/d2/aa3d2157f9ab742a08e0fd8f77d4699f37c22adfbfeb0c610a186b5f75e0/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7876452af029456b3f3549b696bb36a06db7c90747740c5302f74a9e9fa14b13", size = 649304, upload-time = "2024-09-20T17:39:24.55Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/8e/d0aeffe69e53ccff5a28fa86f07ad1d2d2d6537a9506229431a2a02e2f15/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4ead44c85f8ab905852d3de8d86f6f8baf77109f9da589cb4fa142bd3b57b475", size = 646537, upload-time = "2024-09-20T17:44:31.102Z" },
     { url = "https://files.pythonhosted.org/packages/05/79/e15408220bbb989469c8871062c97c6c9136770657ba779711b90870d867/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8320f64b777d00dd7ccdade271eaf0cad6636343293a25074cc5566160e4de7b", size = 642506, upload-time = "2024-09-20T17:08:47.852Z" },
     { url = "https://files.pythonhosted.org/packages/18/87/470e01a940307796f1d25f8167b551a968540fbe0551c0ebb853cb527dd6/greenlet-3.1.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6510bf84a6b643dabba74d3049ead221257603a253d0a9873f55f6a59a65f822", size = 602753, upload-time = "2024-09-20T17:08:38.079Z" },
     { url = "https://files.pythonhosted.org/packages/e2/72/576815ba674eddc3c25028238f74d7b8068902b3968cbe456771b166455e/greenlet-3.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:04b013dc07c96f83134b1e99888e7a79979f1a247e2a9f59697fa14b5862ed01", size = 1122731, upload-time = "2024-09-20T17:44:20.556Z" },
@@ -60,13 +76,38 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/82/8051e82af6d6b5150aacb6789a657a8afd48f0a44d8e91cb72aaaf28553a/greenlet-3.1.1-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:396979749bd95f018296af156201d6211240e7a23090f50a8d5d18c370084dc3", size = 270027, upload-time = "2024-09-20T17:08:27.964Z" },
     { url = "https://files.pythonhosted.org/packages/f9/74/f66de2785880293780eebd18a2958aeea7cbe7814af1ccef634f4701f846/greenlet-3.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca9d0ff5ad43e785350894d97e13633a66e2b50000e8a183a50a88d834752d42", size = 634822, upload-time = "2024-09-20T17:36:54.764Z" },
     { url = "https://files.pythonhosted.org/packages/68/23/acd9ca6bc412b02b8aa755e47b16aafbe642dde0ad2f929f836e57a7949c/greenlet-3.1.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f6ff3b14f2df4c41660a7dec01045a045653998784bf8cfcb5a525bdffffbc8f", size = 646866, upload-time = "2024-09-20T17:39:30.2Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/ab/562beaf8a53dc9f6b2459f200e7bc226bb07e51862a66351d8b7817e3efd/greenlet-3.1.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:94ebba31df2aa506d7b14866fed00ac141a867e63143fe5bca82a8e503b36437", size = 641985, upload-time = "2024-09-20T17:44:36.168Z" },
     { url = "https://files.pythonhosted.org/packages/03/d3/1006543621f16689f6dc75f6bcf06e3c23e044c26fe391c16c253623313e/greenlet-3.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:73aaad12ac0ff500f62cebed98d8789198ea0e6f233421059fa68a5aa7220145", size = 641268, upload-time = "2024-09-20T17:08:52.469Z" },
     { url = "https://files.pythonhosted.org/packages/2f/c1/ad71ce1b5f61f900593377b3f77b39408bce5dc96754790311b49869e146/greenlet-3.1.1-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63e4844797b975b9af3a3fb8f7866ff08775f5426925e1e0bbcfe7932059a12c", size = 597376, upload-time = "2024-09-20T17:08:46.096Z" },
     { url = "https://files.pythonhosted.org/packages/f7/ff/183226685b478544d61d74804445589e069d00deb8ddef042699733950c7/greenlet-3.1.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:7939aa3ca7d2a1593596e7ac6d59391ff30281ef280d8632fa03d81f7c5f955e", size = 1123359, upload-time = "2024-09-20T17:44:27.559Z" },
     { url = "https://files.pythonhosted.org/packages/c0/8b/9b3b85a89c22f55f315908b94cd75ab5fed5973f7393bbef000ca8b2c5c1/greenlet-3.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d0028e725ee18175c6e422797c407874da24381ce0690d6b9396c204c7f7276e", size = 1147458, upload-time = "2024-09-20T17:09:33.708Z" },
     { url = "https://files.pythonhosted.org/packages/b8/1c/248fadcecd1790b0ba793ff81fa2375c9ad6442f4c748bf2cc2e6563346a/greenlet-3.1.1-cp39-cp39-win32.whl", hash = "sha256:5e06afd14cbaf9e00899fae69b24a32f2196c19de08fcb9f4779dd4f004e5e7c", size = 281131, upload-time = "2024-09-20T17:44:53.141Z" },
     { url = "https://files.pythonhosted.org/packages/ae/02/e7d0aef2354a38709b764df50b2b83608f0621493e47f47694eb80922822/greenlet-3.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:3319aa75e0e0639bc15ff54ca327e8dc7a6fe404003496e3c6925cd3142e0e22", size = 298306, upload-time = "2024-09-20T17:33:23.059Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -192,6 +233,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -245,6 +295,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/a3/18508e10a31ea108d746c848b5a05c0711e0278fa0d6f1c52a8ec52b80a5/pandas-2.2.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:31d0ced62d4ea3e231a9f228366919a5ea0b07440d9d4dac345376fd8e1477ea", size = 16783266, upload-time = "2024-09-20T19:02:26.247Z" },
     { url = "https://files.pythonhosted.org/packages/c4/a5/3429bd13d82bebc78f4d78c3945efedef63a7cd0c15c17b2eeb838d1121f/pandas-2.2.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7eee9e7cea6adf3e3d24e304ac6b8300646e2a5d1cd3a3c2abed9101b0846761", size = 14450871, upload-time = "2024-09-20T13:09:59.779Z" },
     { url = "https://files.pythonhosted.org/packages/2f/49/5c30646e96c684570925b772eac4eb0a8cb0ca590fa978f56c5d3ae73ea1/pandas-2.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:4850ba03528b6dd51d6c5d273c46f183f39a9baf3f0143e566b89450965b105e", size = 11618011, upload-time = "2024-09-20T13:10:02.351Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -314,6 +373,59 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -347,6 +459,9 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "psycopg2-binary" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "ruff" },
     { name = "websocket-client" },
 ]
 
@@ -360,7 +475,34 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "ruff", specifier = ">=0.12" },
     { name = "websocket-client", specifier = ">=1.8.0" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
 ]
 
 [[package]]
@@ -444,6 +586,60 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/d3/b9234be8f7d079334a12d5613c1d2c3ceaac2bd531e4d670c107b4189fcc/sqlalchemy_risingwave-1.1.1.tar.gz", hash = "sha256:784de7f87deb39a4a7d792858591efa82aab6f6936f665d029b4b8c5c53ea1e7", size = 12249, upload-time = "2025-02-11T06:29:15.445Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/39/8d386474f2e6305777a9c7b82da4bba8157872fc6c3094a816e2fdaa126d/sqlalchemy_risingwave-1.1.1-py3-none-any.whl", hash = "sha256:6422cd670c4916a107f9f64c155e0a38a8674d862594c8ef212722582cacf58b", size = 11450, upload-time = "2025-02-11T06:29:13.268Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- parameterize row inserts, safely quote identifiers, preserve database defaults, reject unknown columns, and flush pending buffers on close
- fix DataFrame and row buffer ordering, connection URL escaping, subscription connection isolation, checkpoint binding, retry behavior, and resource cleanup
- require RisingWave 2.3+ for subscriptions and add design notes, regression tests, Ruff, and CI enforcement

## Testing

- uv run ruff format --check risingwave tests
- uv run ruff check .
- uv run pytest -q (20 passed)
- uv build
- Python 3.9 unit test run (20 passed)

Real RisingWave integration tests were not run locally because the RisingWave executable is unavailable.