### PR TITLE
feat: validate deployed Python UDF manifests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,7 @@ jobs:
         run: |
           uv run ruff format --check risingwave tests
           uv run ruff check risingwave tests
-          uv run pytest -q
-          uv run --extra udf python -c "import arrow_udf, pyarrow"
+          uv run --extra udf pytest -q
 
       - name: Build package
         run: |

--- a/README.md
+++ b/README.md
@@ -246,8 +246,16 @@ logs, and deployment rollback. Repeated deployments retain the endpoint
 service while creating a new image tag and task-definition revision.
 
 Deployment output is saved under `.rw-udf/deployments/<name>.json`. After the
-RisingWave Cloud PrivateLink flow provides the consumer-visible URL, register
-the deployed bundle through the existing SDK client:
+RisingWave Cloud PrivateLink flow provides the consumer-visible URL, validate
+the advertised function names and Arrow schemas before registration:
+
+```bash
+rw-udf validate \
+  --module my_project.udfs \
+  --udf-url 'http://private-link-endpoint:8815'
+```
+
+Then register the deployed bundle through the existing SDK client:
 
 ```bash
 rw-udf register \
@@ -255,6 +263,11 @@ rw-udf register \
   --dsn 'risingwave://user:password@host:4566/database?sslmode=require' \
   --udf-url 'http://private-link-endpoint:8815'
 ```
+
+Fargate uses the same manifest validation as its ECS container health check.
+The deployment circuit breaker therefore rejects a runtime that only accepts
+TCP connections but is missing a function or advertises an incompatible Arrow
+schema.
 
 AWS credentials and source code are not sent to RisingWave Cloud. The generated
 Docker context excludes common credential, key, environment, VCS, build, and

--- a/risingwave/udf/cli.py
+++ b/risingwave/udf/cli.py
@@ -26,6 +26,16 @@ def _parser() -> argparse.ArgumentParser:
     server.add_argument("--port", type=int, default=8815)
     server.add_argument("--project-root", type=Path, default=Path.cwd())
 
+    validate = commands.add_parser(
+        "validate",
+        help="Validate a deployed bundle over Arrow Flight",
+    )
+    validate.add_argument("--module", required=True)
+    validate.add_argument("--udf-url", required=True)
+    validate.add_argument("--timeout", type=float, default=5)
+    validate.add_argument("--allow-extra-functions", action="store_true")
+    validate.add_argument("--project-root", type=Path, default=Path.cwd())
+
     register = commands.add_parser(
         "register",
         help="Register a deployed bundle in RisingWave",
@@ -83,6 +93,17 @@ def main(argv: list[str] | None = None) -> None:
         from .runtime import serve
 
         serve(args.module, host=args.host, port=args.port)
+        return
+    if args.command == "validate":
+        from .health import validate_flight_manifest
+
+        functions = validate_flight_manifest(
+            args.udf_url,
+            build_manifest(args.module),
+            timeout=args.timeout,
+            allow_extra_functions=args.allow_extra_functions,
+        )
+        print(json.dumps({"ready": True, "functions": functions}, indent=2))
         return
     if args.command == "register":
         from risingwave import RisingWave, RisingWaveConnOptions

--- a/risingwave/udf/deploy/templates/fargate.yaml
+++ b/risingwave/udf/deploy/templates/fargate.yaml
@@ -172,6 +172,18 @@ Resources:
           PortMappings:
             - ContainerPort: !Ref ContainerPort
               Protocol: tcp
+          HealthCheck:
+            Command:
+              - CMD-SHELL
+              - !Sub >-
+                  python -m risingwave.udf.health
+                  --module ${UdfModule}
+                  --udf-url http://127.0.0.1:${ContainerPort}
+                  --timeout 5
+            Interval: 10
+            Timeout: 8
+            Retries: 3
+            StartPeriod: 10
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/risingwave/udf/health.py
+++ b/risingwave/udf/health.py
@@ -1,0 +1,228 @@
+"""Validate an Arrow Flight service against a deployable UDF manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+from urllib.parse import urlsplit
+
+from .bundle import BundleManifest, FunctionManifest, build_manifest
+from .decorators import parse_type
+
+
+class FlightManifestError(RuntimeError):
+    """An Arrow Flight service is unavailable or has an unexpected manifest."""
+
+
+def _load_flight_runtime():
+    try:
+        # Importing arrow_udf registers its JSON and decimal Arrow extension
+        # types before Flight deserializes server schemas.
+        import arrow_udf  # noqa: F401
+        import pyarrow as pa
+        import pyarrow.flight as flight
+    except ImportError as exc:
+        raise RuntimeError(
+            "Arrow Flight validation requires the optional dependencies; "
+            "install risingwave-py[udf]"
+        ) from exc
+    return pa, flight
+
+
+def _flight_location(udf_url: str) -> str:
+    if not isinstance(udf_url, str) or not udf_url.strip():
+        raise ValueError("udf_url must be a non-empty string")
+    parsed = urlsplit(udf_url)
+    schemes = {
+        "http": "grpc",
+        "https": "grpc+tls",
+        "grpc": "grpc",
+        "grpc+tls": "grpc+tls",
+    }
+    try:
+        scheme = schemes[parsed.scheme.lower()]
+    except KeyError as exc:
+        supported = ", ".join(sorted(schemes))
+        raise ValueError(
+            f"unsupported UDF URL scheme {parsed.scheme!r}; expected one of: "
+            f"{supported}"
+        ) from exc
+    if parsed.hostname is None or parsed.port is None:
+        raise ValueError("udf_url must include a host and port")
+    if parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+        raise ValueError("udf_url must not include a path, query, or fragment")
+    host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    return f"{scheme}://{host}:{parsed.port}"
+
+
+def _expected_type_key(sql_type: str) -> tuple[Any, ...]:
+    canonical = parse_type(sql_type).sql
+    if canonical.endswith("[]"):
+        return ("list", _expected_type_key(canonical[:-2]))
+    keys = {
+        "BOOLEAN": ("boolean",),
+        "SMALLINT": ("int16",),
+        "INTEGER": ("int32",),
+        "BIGINT": ("int64",),
+        "REAL": ("float32",),
+        "DOUBLE PRECISION": ("float64",),
+        "VARCHAR": ("string",),
+        "BYTEA": ("binary",),
+        "DATE": ("date32",),
+        "TIME": ("time64", "us"),
+        "TIMESTAMP": ("timestamp", "us"),
+        "DECIMAL": ("extension", "arrowudf.decimal"),
+        "JSONB": ("extension", "arrowudf.json"),
+    }
+    return keys[canonical]
+
+
+def _actual_type_key(pa, data_type: Any) -> tuple[Any, ...]:
+    if pa.types.is_list(data_type):
+        return ("list", _actual_type_key(pa, data_type.value_type))
+    if isinstance(data_type, pa.ExtensionType):
+        return ("extension", data_type.extension_name)
+    predicates = (
+        (pa.types.is_boolean, ("boolean",)),
+        (pa.types.is_int16, ("int16",)),
+        (pa.types.is_int32, ("int32",)),
+        (pa.types.is_int64, ("int64",)),
+        (pa.types.is_float32, ("float32",)),
+        (pa.types.is_float64, ("float64",)),
+        (pa.types.is_string, ("string",)),
+        (pa.types.is_binary, ("binary",)),
+        (pa.types.is_date32, ("date32",)),
+    )
+    for predicate, key in predicates:
+        if predicate(data_type):
+            return key
+    if pa.types.is_time64(data_type):
+        return ("time64", data_type.unit)
+    if pa.types.is_timestamp(data_type):
+        return ("timestamp", data_type.unit)
+    return ("unsupported", str(data_type))
+
+
+def _validate_function_info(
+    pa,
+    function: FunctionManifest,
+    info: Any,
+) -> tuple[str, ...]:
+    errors: list[str] = []
+    argument_count = int(info.total_records)
+    fields = tuple(info.schema)
+    if argument_count != len(function.input_types):
+        errors.append(
+            f"{function.name}: expected {len(function.input_types)} arguments, "
+            f"server reports {argument_count}"
+        )
+        return tuple(errors)
+    if len(fields) != argument_count + 1:
+        errors.append(
+            f"{function.name}: expected {argument_count + 1} Arrow fields, "
+            f"server reports {len(fields)}"
+        )
+        return tuple(errors)
+    for index, (expected, actual) in enumerate(
+        zip(function.input_types, fields[:argument_count])
+    ):
+        if _expected_type_key(expected) != _actual_type_key(pa, actual.type):
+            errors.append(
+                f"{function.name}: argument {index + 1} expected {expected}, "
+                f"server reports {actual.type}"
+            )
+    result = fields[-1]
+    if _expected_type_key(function.return_type) != _actual_type_key(pa, result.type):
+        errors.append(
+            f"{function.name}: return type expected {function.return_type}, "
+            f"server reports {result.type}"
+        )
+    return tuple(errors)
+
+
+def _create_flight_client(flight, location: str):
+    return flight.FlightClient(location)
+
+
+def validate_flight_manifest(
+    udf_url: str,
+    manifest: BundleManifest,
+    *,
+    timeout: float = 5,
+    allow_extra_functions: bool = False,
+) -> tuple[str, ...]:
+    """Validate availability, function names, and Arrow schemas."""
+
+    if (
+        not isinstance(timeout, (int, float))
+        or isinstance(timeout, bool)
+        or timeout <= 0
+    ):
+        raise ValueError("timeout must be positive")
+    pa, flight = _load_flight_runtime()
+    location = _flight_location(udf_url)
+    client = _create_flight_client(flight, location)
+    options = flight.FlightCallOptions(timeout=float(timeout))
+    try:
+        client.wait_for_available(timeout=float(timeout))
+        infos = tuple(client.list_flights(options=options))
+    except Exception as exc:
+        raise FlightManifestError(
+            f"cannot query Arrow Flight service at {udf_url}: {exc}"
+        ) from exc
+
+    advertised: dict[str, Any] = {}
+    for info in infos:
+        path = tuple(info.descriptor.path or ())
+        if len(path) != 1:
+            raise FlightManifestError(
+                f"server returned an invalid Flight descriptor: {path!r}"
+            )
+        name = path[0].decode("utf-8")
+        if name in advertised:
+            raise FlightManifestError(f"server advertises duplicate function {name!r}")
+        advertised[name] = info
+
+    expected_names = {function.name for function in manifest.functions}
+    advertised_names = set(advertised)
+    errors: list[str] = []
+    missing = sorted(expected_names - advertised_names)
+    if missing:
+        errors.append("missing functions: " + ", ".join(missing))
+    if not allow_extra_functions:
+        extra = sorted(advertised_names - expected_names)
+        if extra:
+            errors.append("unexpected functions: " + ", ".join(extra))
+    for function in manifest.functions:
+        info = advertised.get(function.name)
+        if info is not None:
+            errors.extend(_validate_function_info(pa, function, info))
+    if errors:
+        raise FlightManifestError("; ".join(errors))
+    return tuple(sorted(expected_names))
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate a RisingWave Arrow Flight UDF service"
+    )
+    parser.add_argument("--module", required=True)
+    parser.add_argument("--udf-url", required=True)
+    parser.add_argument("--timeout", type=float, default=5)
+    parser.add_argument("--allow-extra-functions", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        functions = validate_flight_manifest(
+            args.udf_url,
+            build_manifest(args.module),
+            timeout=args.timeout,
+            allow_extra_functions=args.allow_extra_functions,
+        )
+    except (FlightManifestError, RuntimeError, ValueError) as exc:
+        parser.exit(1, f"UDF service is not ready: {exc}\n")
+    print(json.dumps({"ready": True, "functions": functions}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_udf_aws.py
+++ b/tests/test_udf_aws.py
@@ -170,6 +170,8 @@ def test_template_uses_consolidated_runtime():
     ).read_text()
 
     assert "risingwave.udf.runtime" in template
+    assert "risingwave.udf.health" in template
+    assert "HealthCheck:" in template
     assert "risingwave_local" not in template
 
 

--- a/tests/test_udf_cli.py
+++ b/tests/test_udf_cli.py
@@ -55,6 +55,39 @@ def test_imports_do_not_eagerly_load_arrow_runtime():
     assert completed.returncode == 0, completed.stderr
 
 
+@patch("risingwave.udf.health.validate_flight_manifest")
+def test_validate_checks_remote_manifest(validate, monkeypatch, capsys, tmp_path):
+    module = ModuleType("test_udf_cli_validate_module")
+
+    @udf.returns("bigint")
+    def identity(value: int):
+        return value
+
+    identity.func.__module__ = module.__name__
+    module.identity = identity
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    validate.return_value = ("identity",)
+
+    main(
+        [
+            "validate",
+            "--module",
+            module.__name__,
+            "--udf-url",
+            "http://private-link.internal:8815",
+            "--project-root",
+            str(tmp_path),
+        ]
+    )
+
+    manifest = validate.call_args.args[1]
+    assert manifest.module == module.__name__
+    assert json.loads(capsys.readouterr().out) == {
+        "ready": True,
+        "functions": ["identity"],
+    }
+
+
 @patch("risingwave.RisingWave")
 @patch("risingwave.RisingWaveConnOptions")
 def test_register_uses_existing_sdk_client(

--- a/tests/test_udf_health.py
+++ b/tests/test_udf_health.py
@@ -1,0 +1,141 @@
+"""Tests for Arrow Flight manifest validation."""
+
+from dataclasses import replace
+
+import pyarrow as pa
+import pyarrow.flight as flight
+import pytest
+
+from risingwave.udf.bundle import BundleManifest, FunctionManifest
+from risingwave.udf.health import (
+    FlightManifestError,
+    _flight_location,
+    validate_flight_manifest,
+)
+
+
+class FakeFlightClient:
+    def __init__(self, infos):
+        self.infos = tuple(infos)
+        self.wait_timeout = None
+        self.options = None
+
+    def wait_for_available(self, timeout):
+        self.wait_timeout = timeout
+
+    def list_flights(self, *, options):
+        self.options = options
+        return iter(self.infos)
+
+
+def _manifest():
+    return BundleManifest(
+        module="app.udfs",
+        functions=(
+            FunctionManifest(
+                name="policy_check",
+                input_types=("VARCHAR", "BIGINT"),
+                return_type="BOOLEAN",
+                batch=False,
+                io_threads=None,
+            ),
+        ),
+    )
+
+
+def _info(
+    *,
+    name="policy_check",
+    input_types=(pa.string(), pa.int64()),
+    return_type=pa.bool_(),
+):
+    schema = pa.schema(
+        [
+            *(
+                pa.field(f"arg{index}", value)
+                for index, value in enumerate(input_types)
+            ),
+            pa.field(name, return_type),
+        ]
+    )
+    return flight.FlightInfo(
+        schema=schema,
+        descriptor=flight.FlightDescriptor.for_path(name),
+        endpoints=[],
+        total_records=len(input_types),
+        total_bytes=0,
+    )
+
+
+def test_validates_function_names_and_arrow_schemas(monkeypatch):
+    client = FakeFlightClient([_info()])
+    monkeypatch.setattr(
+        "risingwave.udf.health._create_flight_client",
+        lambda _flight, location: (
+            client if location == "grpc://private.test:8815" else None
+        ),
+    )
+
+    functions = validate_flight_manifest(
+        "http://private.test:8815",
+        _manifest(),
+        timeout=2,
+    )
+
+    assert functions == ("policy_check",)
+    assert client.wait_timeout == 2
+    assert isinstance(client.options, flight.FlightCallOptions)
+
+
+def test_reports_all_manifest_mismatches(monkeypatch):
+    client = FakeFlightClient(
+        [
+            _info(input_types=(pa.int32(), pa.int64())),
+            _info(name="unexpected", input_types=(), return_type=pa.string()),
+        ]
+    )
+    monkeypatch.setattr(
+        "risingwave.udf.health._create_flight_client",
+        lambda _flight, _location: client,
+    )
+    manifest = replace(
+        _manifest(),
+        functions=(
+            *_manifest().functions,
+            FunctionManifest("missing", (), "VARCHAR", False, None),
+        ),
+    )
+
+    with pytest.raises(FlightManifestError) as error:
+        validate_flight_manifest("http://private.test:8815", manifest)
+
+    message = str(error.value)
+    assert "missing functions: missing" in message
+    assert "unexpected functions: unexpected" in message
+    assert "argument 1 expected VARCHAR" in message
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("http://localhost:8815", "grpc://localhost:8815"),
+        ("https://udf.test:443", "grpc+tls://udf.test:443"),
+        ("grpc://[::1]:8815", "grpc://[::1]:8815"),
+    ],
+)
+def test_normalizes_flight_locations(url, expected):
+    assert _flight_location(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "tcp://localhost:8815",
+        "http://localhost",
+        "http://localhost:8815/path",
+    ],
+)
+def test_rejects_invalid_flight_locations(url):
+    with pytest.raises(ValueError):
+        _flight_location(url)


### PR DESCRIPTION
## Summary

- add an Arrow Flight manifest/schema readiness probe and rw-udf validate
- use the same validation as an ECS container health check
- make the deployment circuit breaker reject missing or incompatible functions

## Stack

- Base: feat/python-udf-deployment
- Next: cloud/python-udf-safe-registration

## Testing

- uv run ruff format --check risingwave tests
- uv run ruff check risingwave tests
- uv run --extra udf pytest -q