### PR TITLE
feat: make Python UDF images reproducible

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ uv run --extra udf --extra multimodal python examples/multimodal_listing.py
 
 The same bundle can run as a foreground Arrow Flight service in a
 customer-owned AWS account. The application project must install
-`risingwave-py[udf]` so the generated image contains the runtime.
+`risingwave-py[udf]` and commit `pyproject.toml` plus `uv.lock` so the generated
+image contains a reproducible runtime.
 
 Prerequisites are Docker, AWS CLI v2 authentication, and the AWS principal that
 RisingWave Cloud will use for the PrivateLink consumer endpoint:
@@ -241,14 +242,23 @@ rw-udf deploy \
   --name policy-prod \
   --region us-east-1 \
   --aws-profile prod \
-  --allowed-principal arn:aws:iam::123456789012:root
+  --allowed-principal arn:aws:iam::123456789012:root \
+  --include models/policy.bin
 ```
 
-The command builds an immutable image, pushes it to ECR, and deploys a
-CloudFormation stack with a dedicated two-AZ VPC, two Fargate tasks by default,
-an internal Network Load Balancer, PrivateLink endpoint service, CloudWatch
-logs, and deployment rollback. Repeated deployments retain the endpoint
-service while creating a new image tag and task-definition revision.
+The generated Docker build uses digest-pinned Python and `uv` images,
+`uv sync --frozen`, and an explicit context allowlist: project metadata,
+`uv.lock`, the top-level package that owns `--module`, common readme/license
+files, and paths named by `--include`. Symlinks that escape the project are
+rejected. The deploy result records hashes for the complete build context,
+manifest, and lockfile together with the locked `risingwave-py` runtime
+version.
+
+The command pushes an immutable image to ECR and deploys a CloudFormation stack
+with a dedicated two-AZ VPC, two Fargate tasks by default, an internal Network
+Load Balancer, PrivateLink endpoint service, CloudWatch logs, and deployment
+rollback. Repeated deployments retain the endpoint service while creating a new
+image tag and task-definition revision.
 
 Deployment output is saved under `.rw-udf/deployments/<name>.json`. After the
 RisingWave Cloud PrivateLink flow provides the consumer-visible URL, validate
@@ -274,10 +284,9 @@ The deployment circuit breaker therefore rejects a runtime that only accepts
 TCP connections but is missing a function or advertises an incompatible Arrow
 schema.
 
-AWS credentials and source code are not sent to RisingWave Cloud. The generated
-Docker context excludes common credential, key, environment, VCS, build, and
-local-state paths. Runtime secrets should be injected through AWS-managed
-secret integrations.
+AWS credentials and source code are not sent to RisingWave Cloud. Undeclared
+project files are not copied into the Docker context. Runtime secrets should be
+injected through AWS-managed secret integrations.
 
 Run the optional Docker end-to-end test with:
 

--- a/risingwave/udf/cli.py
+++ b/risingwave/udf/cli.py
@@ -78,6 +78,12 @@ def _parser() -> argparse.ArgumentParser:
         default=[],
         help="Python project extra to install",
     )
+    deploy.add_argument(
+        "--include",
+        action="append",
+        default=[],
+        help="Additional project-relative path to include in the image",
+    )
     deploy.add_argument("--state-file", type=Path)
     return parser
 
@@ -140,6 +146,7 @@ def main(argv: list[str] | None = None) -> None:
         port=args.port,
         image_uri=args.image_uri,
         extras=tuple(args.extra),
+        build_includes=tuple(args.include),
     )
     result = AwsFargateDeployer(config).deploy(manifest)
     state_file = args.state_file or Path(".rw-udf/deployments") / f"{args.name}.json"

--- a/risingwave/udf/deploy/aws.py
+++ b/risingwave/udf/deploy/aws.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -16,6 +17,46 @@ from typing import Any, Sequence
 from uuid import uuid4
 
 from ..bundle import BundleManifest
+
+DEFAULT_UV_VERSION = "0.9.30"
+DEFAULT_UV_IMAGE = (
+    "ghcr.io/astral-sh/uv:0.9.30"
+    "@sha256:538e0b39736e7feae937a65983e49d2ab75e1559d35041f9878b7b7e51de91e4"
+)
+DEFAULT_PYTHON_IMAGE = (
+    "python:3.12-slim"
+    "@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de"
+)
+_COMMON_PROJECT_FILES = (
+    "README",
+    "README.md",
+    "README.rst",
+    "LICENSE",
+    "LICENSE.md",
+    "LICENSE.txt",
+    "NOTICE",
+    "uv.toml",
+)
+_BUILD_IGNORE_PATTERNS = (
+    ".git",
+    ".venv",
+    ".env",
+    ".env.*",
+    ".rw-udf",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".aws",
+    ".ssh",
+    "__pycache__",
+    "*.pyc",
+    "*.pem",
+    "*.key",
+    "credentials",
+    ".npmrc",
+    ".pypirc",
+    "dist",
+    "build",
+)
 
 
 class CommandError(RuntimeError):
@@ -81,6 +122,10 @@ class FargateConfig:
     port: int = 8815
     image_uri: str | None = None
     extras: tuple[str, ...] = ()
+    build_includes: tuple[str, ...] = ()
+    uv_version: str = DEFAULT_UV_VERSION
+    uv_image: str = DEFAULT_UV_IMAGE
+    python_image: str = DEFAULT_PYTHON_IMAGE
 
     def validate(self) -> None:
         if not isinstance(self.name, str) or not re.fullmatch(
@@ -146,6 +191,49 @@ class FargateConfig:
                 "invalid Python package extras: "
                 + ", ".join(str(value) for value in invalid_extras)
             )
+        if not isinstance(self.build_includes, tuple):
+            raise ValueError("build_includes must be a tuple of relative paths")
+        invalid_includes = [
+            value
+            for value in self.build_includes
+            if not isinstance(value, str)
+            or not value.strip()
+            or Path(value).is_absolute()
+            or ".." in Path(value).parts
+        ]
+        if invalid_includes:
+            raise ValueError(
+                "invalid build include paths: "
+                + ", ".join(str(value) for value in invalid_includes)
+            )
+        if not isinstance(self.uv_version, str) or not re.fullmatch(
+            r"\d+\.\d+\.\d+",
+            self.uv_version,
+        ):
+            raise ValueError("uv_version must be a pinned semantic version")
+        for name, image in (
+            ("uv_image", self.uv_image),
+            ("python_image", self.python_image),
+        ):
+            if not isinstance(image, str) or not re.search(
+                r"@sha256:[0-9a-f]{64}$",
+                image,
+            ):
+                raise ValueError(f"{name} must be pinned by a sha256 digest")
+        if f":{self.uv_version}@" not in self.uv_image:
+            raise ValueError("uv_image tag must match uv_version")
+
+
+@dataclass(frozen=True)
+class BuildMetadata:
+    """Content-addressed metadata for one generated image."""
+
+    image_uri: str
+    build_hash: str
+    manifest_hash: str
+    lock_hash: str
+    runtime_version: str
+    uv_version: str
 
 
 @dataclass(frozen=True)
@@ -159,6 +247,11 @@ class DeploymentResult:
     cluster_name: str
     service_name: str
     manifest: BundleManifest
+    build_hash: str | None = None
+    manifest_hash: str | None = None
+    lock_hash: str | None = None
+    runtime_version: str | None = None
+    uv_version: str | None = None
 
     def to_json(self) -> str:
         return (
@@ -188,10 +281,12 @@ class AwsFargateDeployer:
     def deploy(self, manifest: BundleManifest) -> DeploymentResult:
         self._require_tool("aws")
         image_uri = self.config.image_uri
+        build: BuildMetadata | None = None
         if image_uri is None:
             self._require_tool("docker")
             repository_uri = self._ensure_ecr_repository()
-            image_uri = self._build_and_push(repository_uri, manifest)
+            build = self._build_and_push(repository_uri, manifest)
+            image_uri = build.image_uri
 
         stack_name = f"rw-udf-{self.config.name}"
         self._deploy_stack(stack_name, image_uri)
@@ -214,6 +309,11 @@ class AwsFargateDeployer:
             cluster_name=outputs["ClusterName"],
             service_name=outputs["ServiceName"],
             manifest=manifest,
+            build_hash=None if build is None else build.build_hash,
+            manifest_hash=None if build is None else build.manifest_hash,
+            lock_hash=None if build is None else build.lock_hash,
+            runtime_version=None if build is None else build.runtime_version,
+            uv_version=None if build is None else build.uv_version,
         )
 
     def _require_tool(self, name: str) -> None:
@@ -262,58 +362,37 @@ class AwsFargateDeployer:
         self,
         repository_uri: str,
         manifest: BundleManifest,
-    ) -> str:
-        manifest_hash = hashlib.sha256(
-            manifest.to_json().encode(),
-        ).hexdigest()[:10]
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-        tag = f"{timestamp}-{manifest_hash}-{uuid4().hex[:8]}"
-        image_uri = f"{repository_uri}:{tag}"
-        registry = repository_uri.split("/", 1)[0]
-        password = self.runner.run(
-            self._aws_command("ecr", "get-login-password"),
-        )
-        self.runner.run(
-            (
-                "docker",
-                "login",
-                "--username",
-                "AWS",
-                "--password-stdin",
-                registry,
-            ),
-            input_text=password,
-        )
-
+    ) -> BuildMetadata:
         with tempfile.TemporaryDirectory(prefix="rw-udf-build-") as directory:
             context = Path(directory) / "context"
-            shutil.copytree(
-                self.config.project_root,
+            (
+                build_hash,
+                manifest_hash,
+                lock_hash,
+                runtime_version,
+            ) = self._prepare_build_context(
                 context,
-                symlinks=True,
-                ignore=shutil.ignore_patterns(
-                    ".git",
-                    ".venv",
-                    ".env",
-                    ".env.*",
-                    ".rw-udf",
-                    ".pytest_cache",
-                    ".ruff_cache",
-                    ".aws",
-                    ".ssh",
-                    "__pycache__",
-                    "*.pyc",
-                    "*.pem",
-                    "*.key",
-                    "credentials",
-                    ".npmrc",
-                    ".pypirc",
-                    "dist",
-                    "build",
-                ),
+                manifest,
             )
             dockerfile = context / "Dockerfile.rw-udf"
-            dockerfile.write_text(self._dockerfile())
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+            tag = f"{timestamp}-{build_hash[:12]}-{uuid4().hex[:8]}"
+            image_uri = f"{repository_uri}:{tag}"
+            registry = repository_uri.split("/", 1)[0]
+            password = self.runner.run(
+                self._aws_command("ecr", "get-login-password"),
+            )
+            self.runner.run(
+                (
+                    "docker",
+                    "login",
+                    "--username",
+                    "AWS",
+                    "--password-stdin",
+                    registry,
+                ),
+                input_text=password,
+            )
             self.runner.run(
                 (
                     "docker",
@@ -326,12 +405,153 @@ class AwsFargateDeployer:
                 )
             )
         self.runner.run(("docker", "push", image_uri))
-        return image_uri
+        return BuildMetadata(
+            image_uri=image_uri,
+            build_hash=build_hash,
+            manifest_hash=manifest_hash,
+            lock_hash=lock_hash,
+            runtime_version=runtime_version,
+            uv_version=self.config.uv_version,
+        )
+
+    def _module_include(self) -> Path:
+        top_level = self.config.module.split(".", 1)[0]
+        candidates = (
+            Path(top_level),
+            Path(f"{top_level}.py"),
+            Path("src") / top_level,
+            Path("src") / f"{top_level}.py",
+        )
+        for candidate in candidates:
+            if (self.config.project_root / candidate).exists():
+                return candidate
+        raise ValueError(
+            f"cannot find source for module {self.config.module!r} under "
+            f"{self.config.project_root}; add its package with --include"
+        )
+
+    def _build_include_paths(self) -> tuple[Path, ...]:
+        required = (Path("pyproject.toml"), Path("uv.lock"))
+        missing = [
+            str(path)
+            for path in required
+            if not (self.config.project_root / path).is_file()
+        ]
+        if missing:
+            raise ValueError(
+                "generated UDF images require lockfile-driven projects; missing: "
+                + ", ".join(missing)
+            )
+        candidates = [
+            *required,
+            self._module_include(),
+            *(
+                Path(value)
+                for value in _COMMON_PROJECT_FILES
+                if (self.config.project_root / value).exists()
+            ),
+            *(Path(value) for value in self.config.build_includes),
+        ]
+        selected: list[Path] = []
+        for relative in sorted(
+            set(candidates), key=lambda path: (len(path.parts), str(path))
+        ):
+            source = self.config.project_root / relative
+            if not source.exists() and not source.is_symlink():
+                raise ValueError(f"build include does not exist: {relative}")
+            if any(
+                relative == parent or parent in relative.parents for parent in selected
+            ):
+                continue
+            selected.append(relative)
+        return tuple(selected)
+
+    def _validate_build_source(self, source: Path) -> None:
+        project_root = self.config.project_root.resolve()
+        paths = (source, *source.rglob("*")) if source.is_dir() else (source,)
+        for path in paths:
+            if not path.is_symlink():
+                continue
+            try:
+                target = path.resolve(strict=True)
+                target.relative_to(project_root)
+            except (FileNotFoundError, ValueError) as exc:
+                relative = path.relative_to(self.config.project_root)
+                raise ValueError(
+                    f"build context symlink escapes the project or is broken: "
+                    f"{relative}"
+                ) from exc
+
+    def _copy_build_source(self, relative: Path, context: Path) -> None:
+        source = self.config.project_root / relative
+        self._validate_build_source(source)
+        destination = context / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_dir():
+            shutil.copytree(
+                source,
+                destination,
+                symlinks=True,
+                ignore=shutil.ignore_patterns(*_BUILD_IGNORE_PATTERNS),
+            )
+        else:
+            shutil.copy2(source, destination, follow_symlinks=False)
+
+    @staticmethod
+    def _hash_context(context: Path) -> str:
+        digest = hashlib.sha256()
+        for path in sorted(context.rglob("*"), key=lambda value: value.as_posix()):
+            if path.is_dir():
+                continue
+            relative = path.relative_to(context).as_posix()
+            digest.update(relative.encode())
+            digest.update(b"\0")
+            if path.is_symlink():
+                digest.update(b"symlink\0")
+                digest.update(os.readlink(path).encode())
+            else:
+                digest.update(b"file\0")
+                with path.open("rb") as source:
+                    for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                        digest.update(chunk)
+            digest.update(b"\0")
+        return digest.hexdigest()
+
+    @staticmethod
+    def _locked_runtime_version(lock_text: str) -> str:
+        for block in re.split(r"(?m)^\[\[package\]\]\s*$", lock_text):
+            name = re.search(r'(?m)^name = "([^"]+)"$', block)
+            if name is None or name.group(1) != "risingwave-py":
+                continue
+            version = re.search(r'(?m)^version = "([^"]+)"$', block)
+            if version is not None:
+                return version.group(1)
+        raise ValueError(
+            "uv.lock does not contain risingwave-py; the deployed project must "
+            "install risingwave-py[udf]"
+        )
+
+    def _prepare_build_context(
+        self,
+        context: Path,
+        manifest: BundleManifest,
+    ) -> tuple[str, str, str, str]:
+        context.mkdir(parents=True)
+        for relative in self._build_include_paths():
+            self._copy_build_source(relative, context)
+        manifest_text = manifest.to_json()
+        (context / ".rw-udf-manifest.json").write_text(manifest_text)
+        (context / "Dockerfile.rw-udf").write_text(self._dockerfile())
+        lock_text = (context / "uv.lock").read_text()
+        return (
+            self._hash_context(context),
+            hashlib.sha256(manifest_text.encode()).hexdigest(),
+            hashlib.sha256(lock_text.encode()).hexdigest(),
+            self._locked_runtime_version(lock_text),
+        )
 
     def _dockerfile(self) -> str:
-        install_target = "."
-        if self.config.extras:
-            install_target = f".[{','.join(self.config.extras)}]"
+        extras = "".join(f" --extra {value}" for value in self.config.extras)
         command = json.dumps(
             [
                 "python",
@@ -344,10 +564,18 @@ class AwsFargateDeployer:
             ]
         )
         return (
-            "FROM python:3.12-slim\n"
+            f"FROM {self.config.python_image}\n"
+            f"COPY --from={self.config.uv_image} /uv /uvx /bin/\n"
+            "ENV UV_PROJECT_ENVIRONMENT=/opt/rw-udf \\\n"
+            '    PATH="/opt/rw-udf/bin:$PATH" \\\n'
+            "    UV_COMPILE_BYTECODE=1 \\\n"
+            "    UV_LINK_MODE=copy\n"
             "WORKDIR /app\n"
+            "COPY pyproject.toml uv.lock /app/\n"
+            "RUN uv sync --frozen --no-dev --no-install-project"
+            f"{extras}\n"
             "COPY . /app\n"
-            f'RUN python -m pip install --no-cache-dir "{install_target}"\n'
+            f"RUN uv sync --frozen --no-dev --no-editable{extras}\n"
             f"EXPOSE {self.config.port}\n"
             f"CMD {command}\n"
         )

--- a/tests/test_udf_aws.py
+++ b/tests/test_udf_aws.py
@@ -94,6 +94,16 @@ def _manifest():
     )
 
 
+def _write_build_project(root: Path):
+    (root / "app").mkdir()
+    (root / "app" / "__init__.py").write_text("")
+    (root / "app" / "udfs.py").write_text("value = 1\n")
+    (root / "pyproject.toml").write_text('[project]\nname = "app"\nversion = "1.0.0"\n')
+    (root / "uv.lock").write_text(
+        'version = 1\n\n[[package]]\nname = "risingwave-py"\nversion = "0.0.2"\n'
+    )
+
+
 def test_deploys_existing_image_as_cloudformation_stack(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "risingwave.udf.deploy.aws.shutil.which",
@@ -112,13 +122,17 @@ def test_deploys_existing_image_as_cloudformation_stack(monkeypatch, tmp_path):
     assert "AllowedPrincipals=arn:aws:iam::123456789012:root" in deploy_call
     assert result.endpoint_service_name == "svc.test"
     assert result.manifest == _manifest()
+    assert result.build_hash is None
 
 
-def test_generated_image_runs_new_flight_runtime(tmp_path):
+def test_generated_image_uses_locked_dependencies_and_pinned_builders(tmp_path):
     deployer = AwsFargateDeployer(_config(tmp_path))
     dockerfile = deployer._dockerfile()
 
-    assert 'pip install --no-cache-dir "."' in dockerfile
+    assert "uv sync --frozen --no-dev" in dockerfile
+    assert "pip install" not in dockerfile
+    assert "python:3.12-slim@sha256:" in dockerfile
+    assert "ghcr.io/astral-sh/uv:0.9.30@sha256:" in dockerfile
     assert '"risingwave.udf.runtime"' in dockerfile
     assert '"app.udfs"' in dockerfile
 
@@ -128,35 +142,104 @@ def test_generated_image_installs_requested_extras(tmp_path):
         _config(tmp_path, extras=("multimodal",)),
     )
 
-    assert 'pip install --no-cache-dir ".[multimodal]"' in deployer._dockerfile()
+    assert "--extra multimodal" in deployer._dockerfile()
 
 
-def test_build_context_excludes_secrets_and_preserves_symlinks(tmp_path):
-    (tmp_path / "app.py").write_text("value = 1\n")
+def test_build_context_is_an_explicit_allowlist(tmp_path):
+    _write_build_project(tmp_path)
     (tmp_path / ".env").write_text("TOKEN=secret\n")
     (tmp_path / "private.pem").write_text("secret\n")
+    (tmp_path / "unrelated.txt").write_text("not deployable\n")
     (tmp_path / ".aws").mkdir()
     (tmp_path / ".aws" / "credentials").write_text("secret\n")
-    outside = tmp_path.parent / "outside-secret.txt"
-    outside.write_text("secret\n")
-    (tmp_path / "outside-link").symlink_to(outside)
+    (tmp_path / "model.bin").write_bytes(b"model")
+    (tmp_path / "app" / "data.txt").write_text("data\n")
+    (tmp_path / "app" / ".env.production").write_text("TOKEN=secret\n")
+    (tmp_path / "app" / "data-link").symlink_to("data.txt")
     runner = BuildInspectingRunner()
     deployer = AwsFargateDeployer(
-        _config(tmp_path, image_uri=None),
+        _config(
+            tmp_path,
+            image_uri=None,
+            build_includes=("model.bin",),
+        ),
         runner=runner,
     )
 
-    deployer._build_and_push(
+    build = deployer._build_and_push(
         "123.dkr.ecr.us-east-1.amazonaws.com/repository",
         BundleManifest(module="app.udfs", functions=()),
     )
 
-    assert "app.py" in runner.context_files
+    assert "app/udfs.py" in runner.context_files
+    assert "app/data.txt" in runner.context_files
+    assert "app/data-link" in runner.symlinks
+    assert "model.bin" in runner.context_files
+    assert "pyproject.toml" in runner.context_files
+    assert "uv.lock" in runner.context_files
+    assert ".rw-udf-manifest.json" in runner.context_files
     assert "Dockerfile.rw-udf" in runner.context_files
     assert ".env" not in runner.context_files
+    assert "app/.env.production" not in runner.context_files
     assert "private.pem" not in runner.context_files
     assert ".aws/credentials" not in runner.context_files
-    assert "outside-link" in runner.symlinks
+    assert "unrelated.txt" not in runner.context_files
+    assert len(build.build_hash) == 64
+    assert build.runtime_version == "0.0.2"
+    assert build.image_uri.startswith("123.dkr.ecr.us-east-1.amazonaws.com/repository:")
+
+
+def test_build_context_rejects_escaping_symlinks(tmp_path):
+    _write_build_project(tmp_path)
+    outside = tmp_path.parent / "outside-secret.txt"
+    outside.write_text("secret\n")
+    (tmp_path / "app" / "outside-link").symlink_to(outside)
+    deployer = AwsFargateDeployer(
+        _config(tmp_path, image_uri=None),
+        runner=BuildInspectingRunner(),
+    )
+
+    with pytest.raises(ValueError, match="symlink escapes"):
+        deployer._build_and_push(
+            "123.dkr.ecr.us-east-1.amazonaws.com/repository",
+            BundleManifest(module="app.udfs", functions=()),
+        )
+
+
+def test_generated_build_requires_project_lockfile(tmp_path):
+    (tmp_path / "app").mkdir()
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    deployer = AwsFargateDeployer(
+        _config(tmp_path, image_uri=None),
+        runner=BuildInspectingRunner(),
+    )
+
+    with pytest.raises(ValueError, match="missing: uv.lock"):
+        deployer._build_and_push(
+            "123.dkr.ecr.us-east-1.amazonaws.com/repository",
+            BundleManifest(module="app.udfs", functions=()),
+        )
+
+
+def test_build_hash_covers_source_manifest_and_lockfile(tmp_path):
+    _write_build_project(tmp_path)
+    deployer = AwsFargateDeployer(_config(tmp_path))
+    first = deployer._prepare_build_context(tmp_path / "context-1", _manifest())
+
+    (tmp_path / "app" / "udfs.py").write_text("value = 2\n")
+    second = deployer._prepare_build_context(tmp_path / "context-2", _manifest())
+
+    (tmp_path / "uv.lock").write_text(
+        'version = 1\n\n[[package]]\nname = "risingwave-py"\nversion = "0.0.3"\n'
+    )
+    third = deployer._prepare_build_context(tmp_path / "context-3", _manifest())
+
+    assert first[0] != second[0]
+    assert second[0] != third[0]
+    assert first[1] == second[1] == third[1]
+    assert first[2] == second[2]
+    assert second[2] != third[2]
+    assert third[3] == "0.0.3"
 
 
 def test_template_uses_consolidated_runtime():
@@ -179,6 +262,25 @@ def test_template_uses_consolidated_runtime():
 def test_rejects_invalid_deployment_names(tmp_path, name):
     with pytest.raises(ValueError, match="deployment name"):
         AwsFargateDeployer(_config(tmp_path, name=name))
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("build_includes", ("../secret",), "build include"),
+        ("python_image", "python:3.12-slim", "sha256"),
+        ("uv_image", "ghcr.io/astral-sh/uv:latest", "sha256"),
+        ("uv_version", "latest", "semantic version"),
+    ],
+)
+def test_rejects_unpinned_or_escaping_build_configuration(
+    tmp_path,
+    field,
+    value,
+    message,
+):
+    with pytest.raises(ValueError, match=message):
+        AwsFargateDeployer(_config(tmp_path, **{field: value}))
 
 
 def test_requires_all_cloudformation_outputs(monkeypatch, tmp_path):

--- a/tests/test_udf_cli.py
+++ b/tests/test_udf_cli.py
@@ -163,6 +163,8 @@ def test_deploy_writes_state_file(deployer_type, monkeypatch, capsys, tmp_path):
             str(tmp_path),
             "--image-uri",
             "example.test/image:tag",
+            "--include",
+            "models/policy.bin",
             "--state-file",
             str(state_file),
         ]
@@ -170,3 +172,5 @@ def test_deploy_writes_state_file(deployer_type, monkeypatch, capsys, tmp_path):
 
     assert state_file.read_text() == result.to_json.return_value
     assert capsys.readouterr().out == result.to_json.return_value
+    config = deployer_type.call_args.args[0]
+    assert config.build_includes == ("models/policy.bin",)


### PR DESCRIPTION
## Summary

- build from digest-pinned Python and uv images with uv sync --frozen
- require and hash uv.lock, source, manifest, runtime, and build configuration
- replace whole-project copying with an explicit allowlist plus --include
- reject escaping symlinks and exclude common secret material

## Stack

- Previous: cloud/python-udf-safe-registration
- Next: cloud/python-udf-deployment-history

## Testing

- 88 unit tests passed, 1 skipped
- generated production Docker image built successfully from the repository lockfile