### PR TITLE
feat: record and roll back Python UDF deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,12 +257,26 @@ version.
 The command pushes an immutable image to ECR and deploys a CloudFormation stack
 with a dedicated two-AZ VPC, two Fargate tasks by default, an internal Network
 Load Balancer, PrivateLink endpoint service, CloudWatch logs, and deployment
-rollback. Repeated deployments retain the endpoint service while creating a new
-image tag and task-definition revision.
+rollback. CloudFormation receives the resolved ECR image digest rather than a
+mutable tag. Repeated deployments retain the endpoint service while creating a
+new task-definition revision.
 
-Deployment output is saved under `.rw-udf/deployments/<name>.json`. After the
-RisingWave Cloud PrivateLink flow provides the consumer-visible URL, validate
-the advertised function names and Arrow schemas before registration:
+Deployment output is appended atomically to the versioned history at
+`.rw-udf/deployments/<name>.json`; the previous image digests and manifests are
+not overwritten. Roll back to a compatible recorded version with:
+
+```bash
+rw-udf rollback \
+  --name policy-prod \
+  --version 202607280001 \
+  --aws-profile prod
+```
+
+Rollback refuses to change SQL-visible function signatures. Such a change
+requires an explicit SQL migration.
+
+After the RisingWave Cloud PrivateLink flow provides the consumer-visible URL,
+validate the advertised function names and Arrow schemas before registration:
 
 ```bash
 rw-udf validate \

--- a/risingwave/udf/cli.py
+++ b/risingwave/udf/cli.py
@@ -70,7 +70,7 @@ def _parser() -> argparse.ArgumentParser:
     deploy.add_argument("--port", type=int, default=8815)
     deploy.add_argument(
         "--image-uri",
-        help="Use an existing image and skip Docker/ECR",
+        help="Use an existing digest-pinned image and skip Docker/ECR",
     )
     deploy.add_argument(
         "--extra",
@@ -85,6 +85,16 @@ def _parser() -> argparse.ArgumentParser:
         help="Additional project-relative path to include in the image",
     )
     deploy.add_argument("--state-file", type=Path)
+
+    rollback = commands.add_parser(
+        "rollback",
+        help="Roll an AWS Fargate service back to a recorded image digest",
+    )
+    rollback.add_argument("--name", required=True)
+    rollback.add_argument("--version", required=True)
+    rollback.add_argument("--aws-profile")
+    rollback.add_argument("--project-root", type=Path, default=Path.cwd())
+    rollback.add_argument("--state-file", type=Path)
     return parser
 
 
@@ -131,6 +141,52 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     from .deploy.aws import AwsFargateDeployer, FargateConfig
+    from .deploy.state import DeploymentStateStore, manifests_are_compatible
+
+    if args.command == "rollback":
+        state_file = (
+            args.state_file or Path(".rw-udf/deployments") / f"{args.name}.json"
+        )
+        store = DeploymentStateStore(state_file, name=args.name)
+        history = store.load()
+        latest = history.latest
+        if latest is None:
+            raise RuntimeError(f"no deployment history found for {args.name!r}")
+        target = history.find(args.version)
+        if target.deployment_id == latest.deployment_id:
+            raise RuntimeError(f"deployment {target.deployment_id!r} is already active")
+        if not manifests_are_compatible(latest.manifest, target.manifest):
+            raise RuntimeError(
+                "rollback would change SQL-visible function signatures; "
+                "run an explicit SQL migration instead"
+            )
+        recorded = target.config
+        config = FargateConfig(
+            name=recorded.name,
+            module=recorded.module,
+            project_root=project_root,
+            region=recorded.region,
+            allowed_principals=recorded.allowed_principals,
+            aws_profile=args.aws_profile,
+            desired_count=recorded.desired_count,
+            cpu=recorded.cpu,
+            memory=recorded.memory,
+            port=recorded.port,
+            image_uri=target.image_uri,
+            extras=recorded.extras,
+            build_includes=recorded.build_includes,
+            uv_version=recorded.uv_version,
+            uv_image=recorded.uv_image,
+            python_image=recorded.python_image,
+        )
+        result = AwsFargateDeployer(config).deploy(
+            target.manifest,
+            rollback_of=target.deployment_id,
+            source=target,
+        )
+        store.append(result)
+        print(result.to_json(), end="")
+        return
 
     manifest = build_manifest(args.module)
     config = FargateConfig(
@@ -150,8 +206,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     result = AwsFargateDeployer(config).deploy(manifest)
     state_file = args.state_file or Path(".rw-udf/deployments") / f"{args.name}.json"
-    state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(result.to_json())
+    DeploymentStateStore(state_file, name=args.name).append(result)
     print(result.to_json(), end="")
 
 

--- a/risingwave/udf/deploy/__init__.py
+++ b/risingwave/udf/deploy/__init__.py
@@ -3,13 +3,19 @@
 from .aws import (
     AwsFargateDeployer,
     CommandError,
-    DeploymentResult,
     FargateConfig,
+)
+from .state import (
+    DeploymentHistory,
+    DeploymentResult,
+    DeploymentStateStore,
 )
 
 __all__ = [
     "AwsFargateDeployer",
     "CommandError",
+    "DeploymentHistory",
     "DeploymentResult",
+    "DeploymentStateStore",
     "FargateConfig",
 ]

--- a/risingwave/udf/deploy/aws.py
+++ b/risingwave/udf/deploy/aws.py
@@ -9,7 +9,7 @@ import re
 import shutil
 import subprocess
 import tempfile
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from importlib import resources
 from pathlib import Path
@@ -17,6 +17,7 @@ from typing import Any, Sequence
 from uuid import uuid4
 
 from ..bundle import BundleManifest
+from .state import DeploymentConfig, DeploymentResult
 
 DEFAULT_UV_VERSION = "0.9.30"
 DEFAULT_UV_IMAGE = (
@@ -179,6 +180,11 @@ class FargateConfig:
             not isinstance(self.image_uri, str) or not self.image_uri.strip()
         ):
             raise ValueError("image_uri must be a non-empty string")
+        if self.image_uri is not None and not re.search(
+            r"@sha256:[0-9a-f]{64}$",
+            self.image_uri,
+        ):
+            raise ValueError("image_uri must be pinned by a sha256 digest")
         if not isinstance(self.extras, tuple):
             raise ValueError("extras must be a tuple of project extra names")
         invalid_extras = [
@@ -229,40 +235,13 @@ class BuildMetadata:
     """Content-addressed metadata for one generated image."""
 
     image_uri: str
+    image_tag: str
+    image_digest: str
     build_hash: str
     manifest_hash: str
     lock_hash: str
     runtime_version: str
     uv_version: str
-
-
-@dataclass(frozen=True)
-class DeploymentResult:
-    """Stable infrastructure identifiers returned by a deployment."""
-
-    stack_name: str
-    image_uri: str
-    endpoint_service_name: str
-    load_balancer_dns: str
-    cluster_name: str
-    service_name: str
-    manifest: BundleManifest
-    build_hash: str | None = None
-    manifest_hash: str | None = None
-    lock_hash: str | None = None
-    runtime_version: str | None = None
-    uv_version: str | None = None
-
-    def to_json(self) -> str:
-        return (
-            json.dumps(
-                asdict(self),
-                indent=2,
-                sort_keys=True,
-                default=str,
-            )
-            + "\n"
-        )
 
 
 class AwsFargateDeployer:
@@ -278,7 +257,13 @@ class AwsFargateDeployer:
         self.config = config
         self.runner = runner or ProcessRunner()
 
-    def deploy(self, manifest: BundleManifest) -> DeploymentResult:
+    def deploy(
+        self,
+        manifest: BundleManifest,
+        *,
+        rollback_of: str | None = None,
+        source: DeploymentResult | None = None,
+    ) -> DeploymentResult:
         self._require_tool("aws")
         image_uri = self.config.image_uri
         build: BuildMetadata | None = None
@@ -287,6 +272,9 @@ class AwsFargateDeployer:
             repository_uri = self._ensure_ecr_repository()
             build = self._build_and_push(repository_uri, manifest)
             image_uri = build.image_uri
+        if source is not None and source.image_uri != image_uri:
+            raise ValueError("rollback source image does not match image_uri")
+        image_digest = image_uri.rsplit("@", 1)[-1]
 
         stack_name = f"rw-udf-{self.config.name}"
         self._deploy_stack(stack_name, image_uri)
@@ -301,19 +289,83 @@ class AwsFargateDeployer:
         if missing_outputs:
             missing = ", ".join(sorted(missing_outputs))
             raise RuntimeError(f"CloudFormation stack is missing outputs: {missing}")
+        deployed_at = datetime.now(timezone.utc)
         return DeploymentResult(
+            deployment_id=(
+                deployed_at.strftime("%Y%m%d%H%M%S") + "-" + uuid4().hex[:8]
+            ),
+            deployed_at=deployed_at.isoformat(),
             stack_name=stack_name,
             image_uri=image_uri,
+            image_tag=(
+                build.image_tag
+                if build is not None
+                else None
+                if source is None
+                else source.image_tag
+            ),
+            image_digest=image_digest,
             endpoint_service_name=outputs["EndpointServiceName"],
             load_balancer_dns=outputs["LoadBalancerDns"],
             cluster_name=outputs["ClusterName"],
             service_name=outputs["ServiceName"],
             manifest=manifest,
-            build_hash=None if build is None else build.build_hash,
-            manifest_hash=None if build is None else build.manifest_hash,
-            lock_hash=None if build is None else build.lock_hash,
-            runtime_version=None if build is None else build.runtime_version,
-            uv_version=None if build is None else build.uv_version,
+            config=self._deployment_config(),
+            build_hash=(
+                build.build_hash
+                if build is not None
+                else None
+                if source is None
+                else source.build_hash
+            ),
+            manifest_hash=(
+                build.manifest_hash
+                if build is not None
+                else (
+                    source.manifest_hash
+                    if source is not None and source.manifest_hash is not None
+                    else hashlib.sha256(manifest.to_json().encode()).hexdigest()
+                )
+            ),
+            lock_hash=(
+                build.lock_hash
+                if build is not None
+                else None
+                if source is None
+                else source.lock_hash
+            ),
+            runtime_version=(
+                build.runtime_version
+                if build is not None
+                else None
+                if source is None
+                else source.runtime_version
+            ),
+            uv_version=(
+                build.uv_version
+                if build is not None
+                else None
+                if source is None
+                else source.uv_version
+            ),
+            rollback_of=rollback_of,
+        )
+
+    def _deployment_config(self) -> DeploymentConfig:
+        return DeploymentConfig(
+            name=self.config.name,
+            module=self.config.module,
+            region=self.config.region,
+            allowed_principals=self.config.allowed_principals,
+            desired_count=self.config.desired_count,
+            cpu=self.config.cpu,
+            memory=self.config.memory,
+            port=self.config.port,
+            extras=self.config.extras,
+            build_includes=self.config.build_includes,
+            uv_version=self.config.uv_version,
+            uv_image=self.config.uv_image,
+            python_image=self.config.python_image,
         )
 
     def _require_tool(self, name: str) -> None:
@@ -405,14 +457,43 @@ class AwsFargateDeployer:
                 )
             )
         self.runner.run(("docker", "push", image_uri))
+        image_digest = self._ecr_image_digest(repository_uri, tag)
+        digest_uri = f"{repository_uri}@{image_digest}"
         return BuildMetadata(
-            image_uri=image_uri,
+            image_uri=digest_uri,
+            image_tag=image_uri,
+            image_digest=image_digest,
             build_hash=build_hash,
             manifest_hash=manifest_hash,
             lock_hash=lock_hash,
             runtime_version=runtime_version,
             uv_version=self.config.uv_version,
         )
+
+    def _ecr_image_digest(self, repository_uri: str, tag: str) -> str:
+        try:
+            repository_name = repository_uri.split("/", 1)[1]
+        except IndexError as exc:
+            raise RuntimeError(
+                f"cannot determine ECR repository name from {repository_uri!r}"
+            ) from exc
+        response = self._aws_json(
+            "ecr",
+            "describe-images",
+            "--repository-name",
+            repository_name,
+            "--image-ids",
+            f"imageTag={tag}",
+        )
+        details = response.get("imageDetails") or ()
+        if len(details) != 1:
+            raise RuntimeError(
+                f"ECR did not return one image for {repository_name}:{tag}"
+            )
+        digest = str(details[0].get("imageDigest", ""))
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+            raise RuntimeError(f"ECR returned an invalid image digest: {digest!r}")
+        return digest
 
     def _module_include(self) -> Path:
         top_level = self.config.module.split(".", 1)[0]

--- a/risingwave/udf/deploy/state.py
+++ b/risingwave/udf/deploy/state.py
@@ -1,0 +1,245 @@
+"""Append-only local deployment history for Python UDF services."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from ..bundle import BundleManifest, FunctionManifest
+
+STATE_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class DeploymentConfig:
+    """Non-secret configuration needed to reproduce a service rollout."""
+
+    name: str
+    module: str
+    region: str
+    allowed_principals: tuple[str, ...]
+    desired_count: int
+    cpu: int
+    memory: int
+    port: int
+    extras: tuple[str, ...]
+    build_includes: tuple[str, ...]
+    uv_version: str
+    uv_image: str
+    python_image: str
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "DeploymentConfig":
+        return cls(
+            **{
+                **value,
+                "allowed_principals": tuple(value["allowed_principals"]),
+                "extras": tuple(value["extras"]),
+                "build_includes": tuple(value["build_includes"]),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class DeploymentResult:
+    """One immutable deployment event and its rollback inputs."""
+
+    deployment_id: str
+    deployed_at: str
+    stack_name: str
+    image_uri: str
+    image_digest: str
+    endpoint_service_name: str
+    load_balancer_dns: str
+    cluster_name: str
+    service_name: str
+    manifest: BundleManifest
+    config: DeploymentConfig
+    image_tag: str | None = None
+    build_hash: str | None = None
+    manifest_hash: str | None = None
+    lock_hash: str | None = None
+    runtime_version: str | None = None
+    uv_version: str | None = None
+    rollback_of: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n"
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "DeploymentResult":
+        manifest_value = value["manifest"]
+        manifest = BundleManifest(
+            module=manifest_value["module"],
+            functions=tuple(
+                FunctionManifest(
+                    name=function["name"],
+                    input_types=tuple(function["input_types"]),
+                    return_type=function["return_type"],
+                    batch=function["batch"],
+                    io_threads=function["io_threads"],
+                )
+                for function in manifest_value["functions"]
+            ),
+            protocol=manifest_value.get("protocol", "arrow-flight"),
+            protocol_version=manifest_value.get("protocol_version", 1),
+        )
+        return cls(
+            **{
+                **value,
+                "manifest": manifest,
+                "config": DeploymentConfig.from_dict(value["config"]),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class DeploymentHistory:
+    """Versioned deployment events plus preserved pre-history state."""
+
+    name: str
+    deployments: tuple[DeploymentResult, ...] = ()
+    legacy_deployments: tuple[dict[str, Any], ...] = ()
+    schema_version: int = STATE_SCHEMA_VERSION
+
+    @property
+    def latest(self) -> DeploymentResult | None:
+        return self.deployments[-1] if self.deployments else None
+
+    def append(self, result: DeploymentResult) -> "DeploymentHistory":
+        if result.config.name != self.name:
+            raise ValueError(
+                f"deployment {result.config.name!r} does not belong to history "
+                f"{self.name!r}"
+            )
+        if any(item.deployment_id == result.deployment_id for item in self.deployments):
+            raise ValueError(f"duplicate deployment id: {result.deployment_id}")
+        return DeploymentHistory(
+            name=self.name,
+            deployments=(*self.deployments, result),
+            legacy_deployments=self.legacy_deployments,
+        )
+
+    def find(self, version: str) -> DeploymentResult:
+        exact = [item for item in self.deployments if item.deployment_id == version]
+        if exact:
+            return exact[0]
+        matches = [
+            item for item in self.deployments if item.deployment_id.startswith(version)
+        ]
+        if not matches:
+            raise ValueError(f"deployment version not found: {version}")
+        if len(matches) > 1:
+            raise ValueError(f"deployment version is ambiguous: {version}")
+        return matches[0]
+
+    def to_json(self) -> str:
+        return (
+            json.dumps(
+                {
+                    "schema_version": self.schema_version,
+                    "name": self.name,
+                    "deployments": [
+                        deployment.to_dict() for deployment in self.deployments
+                    ],
+                    "legacy_deployments": self.legacy_deployments,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+
+    @classmethod
+    def from_json(cls, text: str, *, expected_name: str) -> "DeploymentHistory":
+        try:
+            value = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError("deployment state is not valid JSON") from exc
+        if not isinstance(value, dict):
+            raise ValueError("deployment state must contain a JSON object")
+        if "schema_version" not in value:
+            # Preserve the MVP's single-result format instead of overwriting
+            # the only available rollback evidence.
+            return cls(name=expected_name, legacy_deployments=(value,))
+        if value["schema_version"] != STATE_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported deployment state schema: {value['schema_version']}"
+            )
+        if value.get("name") != expected_name:
+            raise ValueError(
+                f"deployment state belongs to {value.get('name')!r}, "
+                f"not {expected_name!r}"
+            )
+        return cls(
+            name=expected_name,
+            deployments=tuple(
+                DeploymentResult.from_dict(item)
+                for item in value.get("deployments", ())
+            ),
+            legacy_deployments=tuple(value.get("legacy_deployments", ())),
+        )
+
+
+class DeploymentStateStore:
+    """Atomically read and append a deployment history file."""
+
+    def __init__(self, path: Path, *, name: str) -> None:
+        self.path = path
+        self.name = name
+
+    def load(self) -> DeploymentHistory:
+        if not self.path.exists():
+            return DeploymentHistory(name=self.name)
+        return DeploymentHistory.from_json(
+            self.path.read_text(),
+            expected_name=self.name,
+        )
+
+    def append(self, result: DeploymentResult) -> DeploymentHistory:
+        history = self.load().append(result)
+        self._write(history)
+        return history
+
+    def _write(self, history: DeploymentHistory) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=self.path.parent,
+                prefix=f".{self.path.name}.",
+                delete=False,
+            ) as temporary:
+                temporary_path = Path(temporary.name)
+                temporary.write(history.to_json())
+                temporary.flush()
+                os.fsync(temporary.fileno())
+            os.chmod(temporary_path, 0o600)
+            os.replace(temporary_path, self.path)
+        finally:
+            if temporary_path is not None and temporary_path.exists():
+                temporary_path.unlink()
+
+
+def manifests_are_compatible(
+    current: BundleManifest,
+    target: BundleManifest,
+) -> bool:
+    """Return whether rollback preserves every SQL-visible signature."""
+
+    def signatures(manifest: BundleManifest):
+        return {
+            (function.name, function.input_types, function.return_type)
+            for function in manifest.functions
+        }
+
+    return signatures(current) == signatures(target)

--- a/tests/test_udf_aws.py
+++ b/tests/test_udf_aws.py
@@ -6,7 +6,11 @@ from pathlib import Path
 import pytest
 
 from risingwave.udf.bundle import BundleManifest, FunctionManifest
-from risingwave.udf.deploy.aws import AwsFargateDeployer, FargateConfig
+from risingwave.udf.deploy.aws import (
+    AwsFargateDeployer,
+    BuildMetadata,
+    FargateConfig,
+)
 
 
 class FakeRunner:
@@ -15,6 +19,16 @@ class FakeRunner:
 
     def run(self, command, *, cwd=None, input_text=None):
         self.calls.append((tuple(command), cwd, input_text))
+        if "describe-images" in command:
+            return json.dumps(
+                {
+                    "imageDetails": [
+                        {
+                            "imageDigest": "sha256:" + "a" * 64,
+                        }
+                    ]
+                }
+            )
         if "describe-stacks" in command:
             return json.dumps(
                 {
@@ -73,7 +87,9 @@ def _config(tmp_path: Path, **overrides):
         "project_root": tmp_path,
         "region": "us-east-1",
         "allowed_principals": ("arn:aws:iam::123456789012:root",),
-        "image_uri": ("123.dkr.ecr.us-east-1.amazonaws.com/rw-udf/policy:sha"),
+        "image_uri": (
+            "123.dkr.ecr.us-east-1.amazonaws.com/rw-udf/policy@sha256:" + "b" * 64
+        ),
     }
     values.update(overrides)
     return FargateConfig(**values)
@@ -123,6 +139,8 @@ def test_deploys_existing_image_as_cloudformation_stack(monkeypatch, tmp_path):
     assert result.endpoint_service_name == "svc.test"
     assert result.manifest == _manifest()
     assert result.build_hash is None
+    assert result.image_digest == "sha256:" + "b" * 64
+    assert result.config.name == "policy-prod"
 
 
 def test_generated_image_uses_locked_dependencies_and_pinned_builders(tmp_path):
@@ -143,6 +161,47 @@ def test_generated_image_installs_requested_extras(tmp_path):
     )
 
     assert "--extra multimodal" in deployer._dockerfile()
+
+
+def test_generated_image_is_deployed_by_resolved_digest(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "risingwave.udf.deploy.aws.shutil.which",
+        lambda _: "/usr/bin/tool",
+    )
+    runner = FakeRunner()
+    deployer = AwsFargateDeployer(
+        _config(tmp_path, image_uri=None),
+        runner=runner,
+    )
+    monkeypatch.setattr(
+        deployer,
+        "_ensure_ecr_repository",
+        lambda: "123.dkr.ecr.us-east-1.amazonaws.com/rw-udf/policy",
+    )
+    digest = "sha256:" + "c" * 64
+    monkeypatch.setattr(
+        deployer,
+        "_build_and_push",
+        lambda _repository, _manifest: BuildMetadata(
+            image_uri=("123.dkr.ecr.us-east-1.amazonaws.com/rw-udf/policy@" + digest),
+            image_tag=("123.dkr.ecr.us-east-1.amazonaws.com/rw-udf/policy:build"),
+            image_digest=digest,
+            build_hash="d" * 64,
+            manifest_hash="e" * 64,
+            lock_hash="f" * 64,
+            runtime_version="0.0.2",
+            uv_version="0.9.30",
+        ),
+    )
+
+    result = deployer.deploy(_manifest())
+
+    deploy_call = next(call[0] for call in runner.calls if "deploy" in call[0])
+    assert (
+        "ImageUri=123.dkr.ecr.us-east-1.amazonaws.com/rw-udf/policy@" + digest
+    ) in deploy_call
+    assert result.image_digest == digest
+    assert result.image_tag.endswith(":build")
 
 
 def test_build_context_is_an_explicit_allowlist(tmp_path):
@@ -186,7 +245,11 @@ def test_build_context_is_an_explicit_allowlist(tmp_path):
     assert "unrelated.txt" not in runner.context_files
     assert len(build.build_hash) == 64
     assert build.runtime_version == "0.0.2"
-    assert build.image_uri.startswith("123.dkr.ecr.us-east-1.amazonaws.com/repository:")
+    assert build.image_uri.startswith(
+        "123.dkr.ecr.us-east-1.amazonaws.com/repository@sha256:"
+    )
+    assert build.image_tag.startswith("123.dkr.ecr.us-east-1.amazonaws.com/repository:")
+    assert build.image_digest == "sha256:" + "a" * 64
 
 
 def test_build_context_rejects_escaping_symlinks(tmp_path):
@@ -271,6 +334,7 @@ def test_rejects_invalid_deployment_names(tmp_path, name):
         ("python_image", "python:3.12-slim", "sha256"),
         ("uv_image", "ghcr.io/astral-sh/uv:latest", "sha256"),
         ("uv_version", "latest", "semantic version"),
+        ("image_uri", "example.test/image:latest", "sha256"),
     ],
 )
 def test_rejects_unpinned_or_escaping_build_configuration(

--- a/tests/test_udf_cli.py
+++ b/tests/test_udf_cli.py
@@ -3,7 +3,7 @@
 import json
 import subprocess
 import sys
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from risingwave.udf import udf
@@ -132,8 +132,15 @@ def test_register_uses_existing_sdk_client(
     assert json.loads(capsys.readouterr().out)["registered"] == 1
 
 
+@patch("risingwave.udf.deploy.state.DeploymentStateStore")
 @patch("risingwave.udf.deploy.aws.AwsFargateDeployer")
-def test_deploy_writes_state_file(deployer_type, monkeypatch, capsys, tmp_path):
+def test_deploy_appends_state_history(
+    deployer_type,
+    state_store_type,
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
     module = ModuleType("test_udf_cli_deploy_module")
 
     @udf.returns("bigint")
@@ -162,7 +169,7 @@ def test_deploy_writes_state_file(deployer_type, monkeypatch, capsys, tmp_path):
             "--project-root",
             str(tmp_path),
             "--image-uri",
-            "example.test/image:tag",
+            "example.test/image@sha256:" + "a" * 64,
             "--include",
             "models/policy.bin",
             "--state-file",
@@ -170,7 +177,82 @@ def test_deploy_writes_state_file(deployer_type, monkeypatch, capsys, tmp_path):
         ]
     )
 
-    assert state_file.read_text() == result.to_json.return_value
+    state_store_type.assert_called_once_with(state_file, name="policy-prod")
+    state_store_type.return_value.append.assert_called_once_with(result)
     assert capsys.readouterr().out == result.to_json.return_value
     config = deployer_type.call_args.args[0]
     assert config.build_includes == ("models/policy.bin",)
+
+
+@patch("risingwave.udf.deploy.state.manifests_are_compatible", return_value=True)
+@patch("risingwave.udf.deploy.state.DeploymentStateStore")
+@patch("risingwave.udf.deploy.aws.AwsFargateDeployer")
+def test_rollback_uses_recorded_digest_and_appends_event(
+    deployer_type,
+    state_store_type,
+    compatible,
+    capsys,
+    tmp_path,
+):
+    manifest = MagicMock()
+    recorded = SimpleNamespace(
+        name="policy-prod",
+        module="app.udfs",
+        region="us-east-1",
+        allowed_principals=("arn:aws:iam::123456789012:root",),
+        desired_count=2,
+        cpu=1024,
+        memory=2048,
+        port=8815,
+        extras=("udf",),
+        build_includes=(),
+        uv_version="0.9.30",
+        uv_image=("ghcr.io/astral-sh/uv:0.9.30@sha256:" + "a" * 64),
+        python_image="python:3.12-slim@sha256:" + "b" * 64,
+    )
+    target = SimpleNamespace(
+        deployment_id="old-version",
+        image_uri="example.test/image@sha256:" + "c" * 64,
+        manifest=manifest,
+        config=recorded,
+    )
+    latest = SimpleNamespace(
+        deployment_id="new-version",
+        manifest=manifest,
+    )
+    history = state_store_type.return_value.load.return_value
+    history.latest = latest
+    history.find.return_value = target
+    result = MagicMock()
+    result.to_json.return_value = '{"rollback_of": "old-version"}\n'
+    deployer_type.return_value.deploy.return_value = result
+    state_file = tmp_path / "policy-prod.json"
+
+    main(
+        [
+            "rollback",
+            "--name",
+            "policy-prod",
+            "--version",
+            "old",
+            "--aws-profile",
+            "prod",
+            "--project-root",
+            str(tmp_path),
+            "--state-file",
+            str(state_file),
+        ]
+    )
+
+    history.find.assert_called_once_with("old")
+    compatible.assert_called_once_with(latest.manifest, target.manifest)
+    config = deployer_type.call_args.args[0]
+    assert config.image_uri == target.image_uri
+    assert config.aws_profile == "prod"
+    deployer_type.return_value.deploy.assert_called_once_with(
+        manifest,
+        rollback_of="old-version",
+        source=target,
+    )
+    state_store_type.return_value.append.assert_called_once_with(result)
+    assert capsys.readouterr().out == result.to_json.return_value

--- a/tests/test_udf_deployment_state.py
+++ b/tests/test_udf_deployment_state.py
@@ -1,0 +1,135 @@
+"""Tests for append-only Python UDF deployment state."""
+
+import json
+
+import pytest
+
+from risingwave.udf.bundle import BundleManifest, FunctionManifest
+from risingwave.udf.deploy.state import (
+    DeploymentConfig,
+    DeploymentHistory,
+    DeploymentResult,
+    DeploymentStateStore,
+    manifests_are_compatible,
+)
+
+
+def _manifest(return_type="VARCHAR"):
+    return BundleManifest(
+        module="app.udfs",
+        functions=(
+            FunctionManifest(
+                name="policy_check",
+                input_types=("VARCHAR",),
+                return_type=return_type,
+                batch=False,
+                io_threads=None,
+            ),
+        ),
+    )
+
+
+def _config():
+    return DeploymentConfig(
+        name="policy-prod",
+        module="app.udfs",
+        region="us-east-1",
+        allowed_principals=("arn:aws:iam::123456789012:root",),
+        desired_count=2,
+        cpu=1024,
+        memory=2048,
+        port=8815,
+        extras=("udf",),
+        build_includes=("models/policy.bin",),
+        uv_version="0.9.30",
+        uv_image="uv@sha256:" + "a" * 64,
+        python_image="python@sha256:" + "b" * 64,
+    )
+
+
+def _result(version, *, manifest=None, rollback_of=None):
+    digest = "sha256:" + version[0] * 64
+    return DeploymentResult(
+        deployment_id=version,
+        deployed_at="2026-07-28T00:00:00+00:00",
+        stack_name="rw-udf-policy-prod",
+        image_uri=f"example.test/policy@{digest}",
+        image_digest=digest,
+        endpoint_service_name="vpce-svc-test",
+        load_balancer_dns="nlb.test",
+        cluster_name="cluster",
+        service_name="service",
+        manifest=manifest or _manifest(),
+        config=_config(),
+        image_tag=f"example.test/policy:{version}",
+        build_hash=version[0] * 64,
+        manifest_hash="c" * 64,
+        lock_hash="d" * 64,
+        runtime_version="0.0.2",
+        uv_version="0.9.30",
+        rollback_of=rollback_of,
+    )
+
+
+def test_state_store_appends_and_round_trips_history(tmp_path):
+    path = tmp_path / "policy-prod.json"
+    store = DeploymentStateStore(path, name="policy-prod")
+    first = _result("first-version")
+    second = _result("second-version")
+
+    store.append(first)
+    history = store.append(second)
+
+    assert history.deployments == (first, second)
+    assert store.load() == history
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_state_store_preserves_legacy_single_result(tmp_path):
+    path = tmp_path / "policy-prod.json"
+    legacy = {"stack_name": "rw-udf-policy-prod", "image_uri": "legacy:tag"}
+    path.write_text(json.dumps(legacy))
+    store = DeploymentStateStore(path, name="policy-prod")
+
+    history = store.append(_result("first-version"))
+
+    assert history.legacy_deployments == (legacy,)
+    assert store.load().legacy_deployments == (legacy,)
+
+
+def test_history_finds_unique_version_prefixes():
+    history = DeploymentHistory(
+        name="policy-prod",
+        deployments=(
+            _result("202607280001-first"),
+            _result("202607280002-second"),
+        ),
+    )
+
+    assert history.find("202607280001").deployment_id == "202607280001-first"
+    with pytest.raises(ValueError, match="ambiguous"):
+        history.find("20260728")
+    with pytest.raises(ValueError, match="not found"):
+        history.find("missing")
+
+
+def test_rollback_compatibility_uses_sql_visible_signatures():
+    current = _manifest()
+    same_signature = BundleManifest(
+        module="old.udfs",
+        functions=current.functions,
+    )
+
+    assert manifests_are_compatible(current, same_signature)
+    assert not manifests_are_compatible(current, _manifest(return_type="BIGINT"))
+
+
+def test_invalid_state_is_not_silently_overwritten(tmp_path):
+    path = tmp_path / "policy-prod.json"
+    path.write_text("{invalid")
+    store = DeploymentStateStore(path, name="policy-prod")
+
+    with pytest.raises(ValueError, match="valid JSON"):
+        store.append(_result("first-version"))
+
+    assert path.read_text() == "{invalid"


### PR DESCRIPTION
## Summary

- resolve pushed ECR tags and deploy immutable sha256 image references
- store deployment results as atomic append-only history while preserving legacy MVP state
- add rw-udf rollback by recorded version
- reject rollback when SQL-visible function signatures differ

## Stack

- Previous: cloud/python-udf-reproducible-builds

## Testing

- 96 unit tests passed, 1 skipped
- package build and wheel contents verified